### PR TITLE
Smaller fixes, again: Devstuff, Coroner Power and Languages 

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,4 +1,4 @@
-environment = "RussStation.dme"
+environment = "tgstation.dme"
 
 [langserver]
 dreamchecker = true

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -31959,7 +31959,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qWz" = (
@@ -42568,6 +42567,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "woR" = (

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -70,6 +70,7 @@
 		/datum/language/dwarvish, //honk - dwarf language
 		/datum/language/queekish, // honk - allows things to switch to it if they know it
 		/datum/language/gamer, // honk - everyone can be a gamer
+		/datum/language/kitsumimetic, // honk - fox
 		/datum/language/moffic,
 		/datum/language/sylvan,
 		/datum/language/shadowtongue,

--- a/russstation/code/modules/language/dwarvish.dm
+++ b/russstation/code/modules/language/dwarvish.dm
@@ -1,5 +1,5 @@
 /datum/language/dwarvish
-	name = "dwarven"
+	name = "Dwarven"
 	icon = 'russstation/icons/misc/language.dmi'
 	desc = "The secret language of the Dwarves."
 	key = "5"

--- a/russstation/code/modules/language/kitsumimetic.dm
+++ b/russstation/code/modules/language/kitsumimetic.dm
@@ -1,7 +1,7 @@
 /datum/language/kitsumimetic
 	name = "Kitsumimetic"
 	desc = "Similar to Nekomimetic in that it resembles Japanese, however this language is comprised mostly of kekkers and various screeches alongside broken syllables."
-	key = "k"
+	key = "w"
 	space_chance = 70
 	syllables = list(
 		"kitsu", "kekker", "mimi", "moe", "mofu", "fuwa", "kyaa", "kawaii", "poka", "munya",


### PR DESCRIPTION
fix: **Changed Kitsumimetic language to ",w"**. Their key was the same as slime language.
fix: Fixed SpacemanDMM for parsing and debug.
fix: Coroner's office in cube had no power (see image).
fix?: Dorf language capitalized, from "dwarven" to "Dwarven".

![image](https://github.com/russ-money/russ-station/assets/19658265/11108358-22a7-47bf-978d-b2d70f66411a)

