### PR TITLE
Reverts dorf changes and some small map fixes

### DIFF
--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -650,7 +650,7 @@
 /area/station/science/lab)
 "amT" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
-/turf/open/space/basic,
+/turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "amW" = (
 /obj/structure/table,
@@ -15501,7 +15501,7 @@
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "miningElevator";
 	pixel_x = 24;
-	preset_destination_names = list("2"="Mining                                                                Office","3"="Mining                                                                Dock")
+	preset_destination_names = list("2"="Mining Office","3"="Mining Dock")
 	},
 /obj/machinery/lift_indicator/directional/east{
 	linked_elevator_id = "miningElevator";
@@ -28628,7 +28628,7 @@
 	desc = "He looks like hes up to no good...";
 	name = "Pleb";
 	real_name = "Pleb";
-	speak_emote = list("ribbit","croak","You                                                                Gay")
+	speak_emote = list("ribbit","croak","You Gay")
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -29909,7 +29909,7 @@
 /area/station/engineering/main)
 "nyR" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
-	atmos_chambers = list("ordnancelab2"="Ordnance                                                                Chamber                                                                2")
+	atmos_chambers = list("ordnancelab2"="Ordnance Chamber 2")
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -15501,7 +15501,7 @@
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "miningElevator";
 	pixel_x = 24;
-	preset_destination_names = list("2"="Mining                                Office","3"="Mining                                Dock")
+	preset_destination_names = list("2"="Mining                                                                Office","3"="Mining                                                                Dock")
 	},
 /obj/machinery/lift_indicator/directional/east{
 	linked_elevator_id = "miningElevator";
@@ -24447,12 +24447,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"lfg" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/spawner/structure/electrified_grille,
-/area/station/hallway/secondary/entry)
 "lfj" = (
 /obj/machinery/door/airlock/external{
 	name = "Maintenance External Access"
@@ -28634,7 +28628,7 @@
 	desc = "He looks like hes up to no good...";
 	name = "Pleb";
 	real_name = "Pleb";
-	speak_emote = list("ribbit","croak","You                                Gay")
+	speak_emote = list("ribbit","croak","You                                                                Gay")
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -29915,7 +29909,7 @@
 /area/station/engineering/main)
 "nyR" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
-	atmos_chambers = list("ordnancelab2"="Ordnance                                Chamber                                2")
+	atmos_chambers = list("ordnancelab2"="Ordnance                                                                Chamber                                                                2")
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
@@ -140488,7 +140482,7 @@ oLX
 sBO
 nsI
 nBf
-lfg
+aCv
 ldV
 vHL
 cbC

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -133,6 +133,7 @@
 /area/station/hallway/secondary/entry)
 "aaT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aaU" = (
@@ -32295,7 +32296,7 @@
 /area/station/engineering/main)
 "pSB" = (
 /obj/machinery/computer/atmos_control/mix_tank{
-	atmos_chambers = list("mix2"="Mix                                                                Chamber                                                                #2");
+	atmos_chambers = list("mix2"="Mix Chamber #2");
 	dir = 1;
 	name = "Gas Mix Tank #2 Control"
 	},
@@ -36770,7 +36771,6 @@
 /turf/open/floor/carpet/red,
 /area/station/service/lawoffice)
 "sxL" = (
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
@@ -42246,7 +42246,7 @@
 /area/station/cargo/warehouse)
 "vGA" = (
 /obj/machinery/computer/atmos_control{
-	atmos_chambers = list("n2"="Nitrogen                                                                Supply","o2"="Oxygen                                                                Supply","co2"="Carbon                                                                Dioxide                                                                Supply","plas"="Plasma                                                                Supply","n2o"="Nitrous                                                                Oxide                                                                Supply","air"="Mixed                                                                Air                                                                Supply","mix"="Mix                                                                Tank","mix2"="Mix                                                                Tank                                                                #2","distro"="Distribution                                                                Loop","waste"="Atmos                                                                Waste                                                                Loop","incinerator"="Incinerator                                                                Chamber","ordnancelab"="Ordnance                                                                Chamber");
+	atmos_chambers = list("n2"="Nitrogen Supply","o2"="Oxygen                                                                                                                                Supply","co2"="Carbon                                                                                                                                Dioxide                                                                                                                                Supply","plas"="Plasma                                                                                                                                Supply","n2o"="Nitrous                                                                                                                                Oxide                                                                                                                                Supply","air"="Mixed                                                                                                                                Air                                                                                                                                Supply","mix"="Mix                                                                                                                                Tank","mix2"="Mix                                                                                                                                Tank                                                                                                                                #2","distro"="Distribution                                                                                                                                Loop","waste"="Atmos                                                                                                                                Waste                                                                                                                                Loop","incinerator"="Incinerator                                                                                                                                Chamber","ordnancelab"="Ordnance                                                                                                                                Chamber");
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -43816,6 +43816,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"wEw" = (
+/turf/closed/wall,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/entry)
 "wEF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -44470,7 +44474,7 @@
 	desc = "He looks like hes up to no good...";
 	name = "Pleb";
 	real_name = "Pleb";
-	speak_emote = list("ribbit","croak","You                                                                Gay")
+	speak_emote = list("ribbit","croak","You Gay")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
@@ -76899,7 +76903,7 @@ gfQ
 pKR
 aaK
 pKR
-xEN
+wEw
 qsO
 xEN
 wnZ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -23871,13 +23871,9 @@
 /area/station/science/ordnance/storage)
 "bHv" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
+/obj/machinery/computer/security/telescreen/ordnance{
 	dir = 4;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = -32
+	pixel_x = -27
 	},
 /obj/structure/closet/crate,
 /obj/item/storage/bag/ore,

--- a/russstation/code/modules/surgery/organs/internal/liver.dm
+++ b/russstation/code/modules/surgery/organs/internal/liver.dm
@@ -3,7 +3,7 @@
 /obj/item/organ/internal/liver/dwarf
 	name = "dwarf liver"
 	desc = "A liver evolved for alcohol processing."
-	maxHealth = STANDARD_ORGAN_THRESHOLD*0.65
+	maxHealth = STANDARD_ORGAN_THRESHOLD
 	toxTolerance = 2
 
 /obj/item/organ/internal/liver/dwarf/handle_chemical(mob/living/carbon/organ_owner, datum/reagent/chem, seconds_per_tick, times_fired)

--- a/russstation/code/modules/surgery/organs/internal/liver.dm
+++ b/russstation/code/modules/surgery/organs/internal/liver.dm
@@ -2,7 +2,7 @@
 
 /obj/item/organ/internal/liver/dwarf
 	name = "dwarf liver"
-	desc = "A liver evolved for exclusive alcohol processing, demonstrating regenerative capabilities when processing a particular drink."
+	desc = "A liver evolved for alcohol processing."
 	maxHealth = STANDARD_ORGAN_THRESHOLD*0.65
 	toxTolerance = 2
 
@@ -11,16 +11,8 @@
 	// parent returned COMSIG_MOB_STOP_REAGENT_CHECK or we are failing
 	if((. & COMSIG_MOB_STOP_REAGENT_CHECK) || (organ_flags & ORGAN_FAILING))
 		return
-	if(istype(chem, /datum/reagent/)) // Every chem hurts the liver, but manly dorf heals it
-		if(istype(chem, /datum/reagent/consumable/ethanol))
-			organ_owner.adjustBruteLoss(-0.9 * REM * seconds_per_tick)
-			organ_owner.adjustFireLoss(-0.9 * REM * seconds_per_tick)
-			if(istype(chem, /datum/reagent/consumable/ethanol/manly_dorf))
-				organ_owner.adjustOrganLoss(ORGAN_SLOT_LIVER, -1.0 * REM * seconds_per_tick) // This will get added to natural regen
-				return
-			return // Ethanol returns before hurting liver
 
-		organ_owner.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.5 * REM * seconds_per_tick)
+	if(istype(chem, /datum/reagent/consumable/ethanol))
+		organ_owner.adjustBruteLoss(-0.9 * REM * seconds_per_tick)
+		organ_owner.adjustFireLoss(-0.9 * REM * seconds_per_tick)
 		return
-
-


### PR DESCRIPTION
This is basically the same old dwarf code but now they can lose their liver and their powers with it.
Health is back up to 100 too, as alcohol deals liver damage.

Also removed icecube space tiles and pubby ordnance telescreen and a weird light in lima arrivals