### PR TITLE
Add skaven smoker to junkie

### DIFF
--- a/code/datums/quirks/negative_quirks/junkie.dm
+++ b/code/datums/quirks/negative_quirks/junkie.dm
@@ -130,8 +130,12 @@
 			smoker_lungs = /obj/item/organ/internal/lungs/plasmaman/plasmaman_smoker
 		else if(isethereal(carbon_holder))
 			smoker_lungs = /obj/item/organ/internal/lungs/ethereal/ethereal_smoker
+			
+		// honk start - adds skaven to smoker trait
 		else if(isskaven(carbon_holder))
 			smoker_lungs = /obj/item/organ/internal/lungs/skaven/skaven_smoker
+		// honk end
+		
 		else
 			smoker_lungs = /obj/item/organ/internal/lungs/smoker_lungs
 	if(!isnull(smoker_lungs))

--- a/code/datums/quirks/negative_quirks/junkie.dm
+++ b/code/datums/quirks/negative_quirks/junkie.dm
@@ -130,6 +130,8 @@
 			smoker_lungs = /obj/item/organ/internal/lungs/plasmaman/plasmaman_smoker
 		else if(isethereal(carbon_holder))
 			smoker_lungs = /obj/item/organ/internal/lungs/ethereal/ethereal_smoker
+		else if(isskaven(carbon_holder))
+			smoker_lungs = /obj/item/organ/internal/lungs/skaven/skaven_smoker
 		else
 			smoker_lungs = /obj/item/organ/internal/lungs/smoker_lungs
 	if(!isnull(smoker_lungs))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-adds Skaven smoker that yui added in 0db7c1a

## Why It's Good For The Game

Fixes Skaven smokers to not breath O2

## Changelog

:cl:
Re-added Skaven smoker lungs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
