### PR TITLE
Enable auxtools

### DIFF
--- a/config/auxtools.txt
+++ b/config/auxtools.txt
@@ -3,4 +3,4 @@
 ## Currently, this will disable Lua scripting.
 ##
 
-#AUXTOOLS_ENABLED
+AUXTOOLS_ENABLED


### PR DESCRIPTION
Enables auxtools (Lua scripting for admins). Might be able to make some fun events or some such with advanced lua scripting in place of SDQL.