### PR TITLE
Puppy station tune ups

### DIFF
--- a/_maps/map_files/Mining/IceMoon.dmm
+++ b/_maps/map_files/Mining/IceMoon.dmm
@@ -803,6 +803,13 @@
 /obj/item/emergency_bed,
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
+"qw" = (
+/obj/structure/ore_vent/starter_resources{
+	icon_state = "ore_vent_ice_active";
+	icon_state_tapped = "ore_vent_ice_active"
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "qJ" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood,
@@ -1010,8 +1017,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock";
-	req_access = null
+	name = "Mining External Airlock"
 	},
 /turf/open/floor/iron/textured,
 /area/mine/eva)
@@ -1382,8 +1388,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock";
-	req_access = null
+	name = "Mining External Airlock"
 	},
 /turf/open/floor/iron/textured,
 /area/mine/eva)
@@ -59382,7 +59387,7 @@ kj
 kj
 kj
 kj
-kj
+Xz
 kj
 kj
 kj
@@ -60150,8 +60155,8 @@ kj
 kj
 kj
 kj
+qw
 kj
-Xz
 kj
 kj
 kj

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -25,25 +25,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aae" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Incinerator"
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
-	dir = 4;
-	name = "turbine vent monitor";
-	network = list("turbine");
-	pixel_x = -29
-	},
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/disposal/incinerator)
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "aaf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -84,90 +70,69 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aam" = (
-/obj/machinery/module_duplicator,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aap" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/station/science/circuits)
-"aar" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aas" = (
-/obj/machinery/door/airlock/research{
-	name = "Circuits Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/machinery/computer/scan_consolenew,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aat" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/cargo)
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "aau" = (
-/obj/structure/cable,
-/obj/machinery/component_printer,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 6
+	},
+/obj/item/clothing/gloves/latex,
 /obj/machinery/camera/directional/north{
-	c_tag = "Circuit Lab";
+	c_tag = "Genetics";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aav" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/engine,
-/area/station/science/circuits)
-"aaw" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	pixel_y = 7
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aax" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/station/science/circuits)
-"aay" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"aay" = (
+/obj/machinery/dna_scannernew,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aaz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/machinery/computer/scan_consolenew{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aaB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/item/kirbyplants/organic/plant11,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"aaC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/engine,
-/area/station/science/circuits)
 "aaD" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -177,48 +142,50 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"aaF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/station/science/circuits)
 "aaG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/pen{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/obj/structure/sign/poster/official/science/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aaH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/effect/mapping_helpers/apc/cell_5k,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "aaI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
-"aaJ" = (
-/obj/machinery/computer/security/qm{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "TrashMover"
 	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/structure/sign/poster/random/directional/south,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"aaJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/turf/open/space,
+/area/space/nearstation)
 "aaK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/item/kirbyplants/organic/plant21,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "aaL" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -239,33 +206,23 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aaO" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/sunny/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/hallway/primary/central)
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "aaP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "aaQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aaR" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/machinery/disposal/bin,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aaT" = (
@@ -279,12 +236,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"aaV" = (
-/obj/machinery/doppler_array,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "aaW" = (
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/mesh,
@@ -307,12 +258,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aaZ" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "aba" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -335,35 +283,44 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "abd" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "abe" = (
-/obj/effect/landmark/start/quartermaster,
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "abf" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "abg" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/engineering/lobby)
 "abh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/structure/rack,
+/obj/item/clothing/under/misc/mailman,
+/obj/item/clothing/head/costume/mailman,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -389,9 +346,9 @@
 /turf/open/space,
 /area/space)
 "abO" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "abV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -429,14 +386,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "acf" = (
@@ -448,27 +403,33 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "ach" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/engine,
+/area/station/science/explab)
+"aci" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"aci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "acj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "ack" = (
-/obj/machinery/porta_turret_construct,
+/obj/machinery/porta_turret/ai{
+	installation = /obj/item/gun/energy/e_gun
+	},
 /turf/open/floor/plating/airless,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "acl" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/cup/beaker/large,
@@ -511,17 +472,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "acr" = (
-/obj/machinery/modular_computer/preset/cargochat/medical{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"acs" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/station/science/ordnance/storage)
 "act" = (
 /obj/structure/closet/crate{
 	name = "License Crate"
@@ -542,17 +496,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "acv" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	name = "Medbay RC";
-	pixel_y = 30
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "acw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -561,23 +507,23 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "acy" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 4
+	},
+/obj/machinery/air_sensor/ordnance_freezer_chamber,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
+"acA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
-"acA" = (
-/turf/closed/wall/r_wall,
-/area/station/science/circuits)
-"acB" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Ordnance Storage";
-	network = list("ss13","rd")
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/station/science/ordnance/storage)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "acC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -587,25 +533,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"acE" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating,
-/area/station/science/ordnance)
 "acF" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"acI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "acJ" = (
 /obj/structure/sink/kitchen/directional/south,
 /turf/open/floor/iron/cafeteria,
@@ -629,25 +562,20 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "acN" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/landmark/start/ai/secondary,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "acO" = (
 /obj/structure/grille/broken,
 /turf/open/space,
 /area/space/nearstation)
 "acP" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "acR" = (
-/obj/structure/table/glass,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/closed/wall/r_wall,
+/area/station/medical/virology)
 "acS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -675,28 +603,34 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "acX" = (
-/obj/structure/frame/computer,
+/obj/machinery/computer/atmos_alert,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "acY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adb" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "AI Core"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/iron/dark,
-/area/space/nearstation)
+/area/station/ai_monitored/turret_protected/ai)
 "add" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/ai_monitored/turret_protected/ai)
 "ade" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/iron,
@@ -713,33 +647,35 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adf" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adg" = (
-/obj/structure/frame/machine,
+/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adh" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = 6;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/item/folder/white{
+	pixel_x = -11;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/item/pen,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "adi" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adj" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/clothing/ears/earmuffs,
@@ -758,17 +694,21 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adm" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -785,77 +725,92 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
 /obj/structure/table,
 /obj/item/pen,
-/obj/machinery/firealarm/directional/east,
 /obj/item/paper_bin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
-"adq" = (
-/obj/machinery/shower/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/station/ai_monitored/turret_protected/aisat_interior)
+"adq" = (
+/obj/structure/table/glass,
+/obj/item/soap/deluxe,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Aft Hall";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/medical/medbay/central)
 "adr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "ads" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Maintenance Port Aft";
+	network = list("minisat")
+	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-inner"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adx" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adz" = (
 /obj/machinery/light/small/directional/south,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_y = -29
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat AI Chamber Observation";
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "AI Monitoring"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adA" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -865,14 +820,17 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-inner"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -882,67 +840,83 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "adD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 4;
-	name = "AI Sat Waste"
+/obj/machinery/camera/directional/south{
+	c_tag = "MiniSat Maintenance Starboard Fore";
+	network = list("minisat")
 	},
-/mob/living/basic/cockroach,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adH" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance"
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "adI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adJ" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
-"adK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
+"adK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adM" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Chamber Observation"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-center"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adN" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-right"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adR" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -950,11 +924,10 @@
 /area/space/nearstation)
 "adS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adT" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -967,28 +940,29 @@
 /area/station/science/explab)
 "adU" = (
 /obj/machinery/recharge_station,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "adW" = (
-/obj/structure/lattice,
 /obj/machinery/light/small/directional/north,
-/turf/open/space/basic,
-/area/station/ai_monitored/aisat/exterior)
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Bridge Starboard Fore";
+	network = list("minisat")
+	},
+/turf/open/floor/plating/airless,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "adZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/basic/cockroach,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "aea" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -1007,33 +981,28 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "aec" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/maintenance/department/engine)
 "aed" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
 /area/space/nearstation)
 "aee" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "aef" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Project Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/engineering/atmos/hfr_room)
 "aeh" = (
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "aej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1042,14 +1011,19 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "aek" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/screwdriver,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/medbay/central)
 "ael" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "aem" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison)
@@ -1087,7 +1061,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "aes" = (
-/obj/effect/turf_decal/trimline/blue/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aet" = (
@@ -1105,39 +1084,42 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aev" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "aew" = (
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "aex" = (
-/obj/structure/lattice,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "MiniSat Bridge Port Aft";
 	network = list("minisat")
 	},
-/turf/open/space/basic,
-/area/station/ai_monitored/aisat/exterior)
+/turf/open/floor/plating/airless,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aey" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/obj/machinery/modular_computer/preset/cargochat/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "aez" = (
-/obj/structure/lattice,
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat Bridge Starboard Aft";
+	network = list("minisat")
+	},
 /obj/machinery/light/small/directional/south,
-/turf/open/space/basic,
-/area/station/ai_monitored/aisat/exterior)
+/turf/open/floor/plating/airless,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aeB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeC" = (
 /obj/effect/spawner/random/contraband/permabrig_weapon,
 /turf/open/floor/carpet,
@@ -1156,12 +1138,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aeG" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Incinerator"
+	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/maintenance/disposal/incinerator)
 "aeI" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Office"
@@ -1171,14 +1156,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "aeJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "aeK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1200,17 +1183,18 @@
 /area/station/security/warden)
 "aeO" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Chamber Hallway"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-center"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aeP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1221,16 +1205,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
 "aeS" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "aeT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
@@ -1239,28 +1219,6 @@
 /obj/structure/flora/bush/ferny/style_random,
 /turf/open/floor/grass,
 /area/station/security/prison)
-"aeV" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -7;
-	pixel_y = 11
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -6
-	},
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 10;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 9;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "aeW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/east,
@@ -1273,15 +1231,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "aeY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "aeZ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afa" = (
 /turf/open/floor/carpet,
 /area/station/security/prison)
@@ -1292,33 +1254,43 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "afc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afe" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -1328,43 +1300,48 @@
 	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afi" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "afj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/freezerchamber)
 "afk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "afl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/maintenance/fore)
 "afm" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "afn" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
@@ -1406,45 +1383,53 @@
 	name = "Air Out"
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afw" = (
 /obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afx" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afy" = (
+/obj/effect/landmark/start/cyborg,
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afz" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afA" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1452,7 +1437,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "afC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1511,58 +1496,51 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afL" = (
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afM" = (
 /obj/structure/table,
 /obj/item/crowbar,
 /obj/item/clothing/mask/gas,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afN" = (
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/sign/departments/aisat/directional/west,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afP" = (
 /obj/machinery/holopad/secure,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/sign/departments/aisat/directional/east,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
-"afS" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating,
-/area/station/science/ordnance)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "afT" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -1577,7 +1555,7 @@
 	layer = 4
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "afU" = (
 /turf/closed/wall,
 /area/station/security/execution/transfer)
@@ -1623,19 +1601,20 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agf" = (
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agg" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/machinery/requests_console/directional/south{
+	department = "AI";
+	name = "AI Satellite Requests Console"
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1661,12 +1640,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "agl" = (
-/obj/structure/cable,
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/psychologist,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "agn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
@@ -1683,9 +1658,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "agq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/obj/machinery/ai_slipper{
+	uses = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "agr" = (
 /obj/machinery/computer/teleporter{
 	dir = 4
@@ -1694,26 +1676,22 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "ags" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agt" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/structure/barricade/wooden,
+/obj/machinery/computer/monitor,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "agu" = (
+/obj/structure/transit_tube,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agv" = (
 /turf/closed/wall/r_wall,
 /area/station/security/lockers)
@@ -1726,40 +1704,25 @@
 /turf/closed/wall,
 /area/station/security/prison)
 "agz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/item/wrench/medical,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "agA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"agB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "agD" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -1819,7 +1782,6 @@
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "agP" = (
@@ -1830,15 +1792,15 @@
 /turf/open/floor/plating,
 /area/station/security)
 "agR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "agS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1929,19 +1891,10 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "ahp" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Genetics Lab West"
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "ahq" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/potato,
@@ -1953,14 +1906,31 @@
 /turf/open/floor/grass,
 /area/station/security/prison)
 "ahr" = (
-/obj/structure/sign/departments/psychology/directional/south,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock"
+	},
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access = list("virology")
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-viro";
+	id_tag = "viro-access"
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/virology)
 "ahs" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/spawner/random/trash/graffiti,
@@ -1972,18 +1942,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ahu" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/medical_kiosk,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "ahv" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "ahw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2021,21 +1988,9 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ahK" = (
-/obj/structure/sign/departments/exam_room/directional/north,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "ahL" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
-"ahM" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "ahN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -2058,17 +2013,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"ahR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 10
-	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "ahS" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
@@ -2076,9 +2020,6 @@
 /area/station/security/prison)
 "ahT" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "ahU" = (
@@ -2086,10 +2027,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "ahV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "ahW" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot,
@@ -2161,16 +2101,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"aij" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "aik" = (
 /obj/item/storage/box/lethalshot,
 /obj/machinery/camera/directional/north{
@@ -2220,12 +2150,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "air" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "ais" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2332,16 +2260,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "aiL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/item/toy/plush/plasmamanplushie,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "aiM" = (
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -2395,10 +2316,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "aiX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Port"
 	},
+/obj/machinery/button/door/directional/west{
+	id = "atmos_project";
+	name = "Project Shutters";
+	req_access = list("atmospherics")
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aiY" = (
@@ -2452,13 +2378,18 @@
 /turf/open/floor/iron,
 /area/station/security)
 "ajf" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/machinery/door/airlock/medical{
+	name = "Surgical Theatres"
 	},
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/light/directional/west,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/surgery)
 "ajg" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
@@ -2520,12 +2451,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ajk" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "ajl" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -2562,9 +2489,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "ajr" = (
-/obj/effect/turf_decal/trimline/blue/corner,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ajs" = (
@@ -2638,13 +2571,6 @@
 /obj/effect/spawner/random/bedsheet,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"ajF" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "ajG" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -2664,7 +2590,7 @@
 /area/station/security/prison)
 "ajJ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ajK" = (
@@ -3009,9 +2935,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "akC" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/structure/window/reinforced/spawner/directional/west,
+/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "akD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -3097,16 +3026,7 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "akU" = (
-/obj/structure/table/glass,
-/obj/item/stack/medical/gauze,
-/obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/turf/closed/wall,
 /area/station/command/heads_quarters/cmo)
 "akV" = (
 /obj/structure/cable,
@@ -3273,11 +3193,9 @@
 /turf/open/floor/iron,
 /area/station/security)
 "als" = (
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
-/obj/machinery/computer/shuttle/mining{
-	dir = 8
+/mob/living/basic/mothroach{
+	desc = "That's mining's pet mothroach Aemilia. Affectionately known as the mini Darkheart they're quite sweet, offering weary miners reassurance after long days of carving hardened basalt and running from megafauna.";
+	name = "Aemilia"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -3297,26 +3215,28 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aly" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/pipedispenser,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "alz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "alA" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "alB" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "alC" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -3368,12 +3288,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "alI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/storage)
 "alJ" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
@@ -3442,26 +3363,21 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ama" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "amb" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/station/security)
 "amc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "CMO Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "ame" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/prison/directional/east,
@@ -3487,15 +3403,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/ai_monitored/security/armory)
-"ami" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "amk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
@@ -3515,21 +3422,12 @@
 /turf/closed/wall,
 /area/station/security/execution/education)
 "amo" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/soap/deluxe,
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/station/medical/surgery)
 "amp" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/science/explab)
 "amq" = (
 /obj/effect/turf_decal/delivery,
@@ -3583,9 +3481,11 @@
 /turf/open/floor/carpet,
 /area/station/security/prison)
 "amz" = (
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "amA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet,
@@ -3692,10 +3592,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "anb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "anc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -3772,13 +3671,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ans" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/machinery/door/window/right/directional/east{
+	name = "Arena"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "anv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -3786,12 +3685,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
-"anw" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/kirbyplants/random/fullysynthetic,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "anx" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -3799,15 +3692,6 @@
 /obj/structure/flora/bush/jungle/b/style_random,
 /turf/open/floor/grass,
 /area/station/medical/storage)
-"any" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "anB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -3882,10 +3766,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "anQ" = (
-/obj/machinery/computer/cargo,
-/obj/structure/window/reinforced/spawner/directional/north{
-	pixel_y = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/south{
+	name = "Cargo Desk";
+	req_access = list("shipping")
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "anR" = (
@@ -3894,30 +3780,29 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "anS" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/rxglasses,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "anT" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/button/door{
-	id = "surgerya";
-	name = "Privacy Shutters Control";
-	pixel_x = -26
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = -25;
-	pixel_y = -9
+/obj/machinery/requests_console{
+	department = "Chief Medical Officer's Desk";
+	name = "Chief Medical Officer RC";
+	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/area/station/command/heads_quarters/cmo)
 "anU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4130,10 +4015,11 @@
 /turf/open/floor/iron,
 /area/station/security)
 "aoR" = (
-/obj/machinery/disposal/bin,
+/obj/structure/sink/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "aoS" = (
@@ -4178,16 +4064,6 @@
 /obj/item/laser_pointer/red,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
-"aoX" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/pen,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/lipstick/black,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/item/reagent_containers/pill/morphine,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
 "aoY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light_switch{
@@ -4211,6 +4087,7 @@
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "ape" = (
@@ -4227,16 +4104,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "apf" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "north-atmos-shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "apg" = (
@@ -4247,8 +4115,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "aph" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "api" = (
 /obj/structure/closet/secure_closet/brig{
@@ -4266,7 +4136,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "apk" = (
@@ -4367,25 +4239,27 @@
 /area/station/service/hydroponics)
 "apK" = (
 /obj/structure/table/glass,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
+/obj/item/surgery_tray/full,
+/obj/item/book/manual/wiki/medicine{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = -4;
+	pixel_y = -1
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "apL" = (
-/obj/structure/cable,
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/hallway/primary/central)
 "apM" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -4398,7 +4272,13 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "apQ" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "apR" = (
@@ -4412,8 +4292,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "apS" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "apT" = (
@@ -4573,10 +4455,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"aqD" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "aqE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -4729,7 +4607,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "arm" = (
 /obj/structure/sign/poster/official/safety_report/directional/north,
 /obj/structure/closet{
@@ -4820,11 +4698,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "arC" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
+/obj/structure/transit_tube/station/dispenser/flipped{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "arD" = (
@@ -5126,19 +5003,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "asB" = (
-/obj/item/computer_disk/medical,
-/obj/item/computer_disk/medical,
-/obj/item/computer_disk/medical,
-/obj/structure/table,
-/obj/item/wrench/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "asD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -5186,18 +5055,22 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "asM" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
-"asN" = (
-/obj/structure/sign/warning/vacuum/external/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
-"asO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/turf/open/floor/iron,
+/area/station/maintenance/fore)
+"asN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/fore)
+"asO" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/any_snack_or_beverage,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "asQ" = (
@@ -5481,14 +5354,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "atM" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
+/obj/machinery/door/airlock/command{
+	name = "MiniSat Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/landmark/navigate_destination/minisat_access_ai,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "atN" = (
 /obj/structure/table/wood,
@@ -5749,12 +5625,11 @@
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "auB" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "auC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5767,15 +5642,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "auD" = (
-/obj/machinery/suit_storage_unit/cmo,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "auE" = (
 /obj/machinery/computer/records/security,
 /obj/machinery/button/door{
@@ -5834,9 +5704,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "auL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/aft)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "auN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -6186,33 +6056,45 @@
 /area/station/maintenance/fore)
 "avM" = (
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "avN" = (
-/obj/effect/spawner/random/trash/botanical_waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/structure/sign/poster/random/directional/north,
+/obj/structure/table,
+/obj/item/hfr_box/core{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = 3
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = -5
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 11
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "avO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "avP" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "south-atmos-shutters"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "avQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6225,6 +6107,7 @@
 	cycle_id = "bridge-maint"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "avR" = (
@@ -6233,6 +6116,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "avS" = (
@@ -6616,12 +6500,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "awX" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "awY" = (
@@ -6689,8 +6568,12 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
 "axj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination{
+	location = "Xenobiology"
+	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "axk" = (
@@ -6722,6 +6605,11 @@
 "axu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "axv" = (
@@ -6753,12 +6641,14 @@
 /turf/closed/wall,
 /area/station/maintenance/solars/port)
 "axE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "axF" = (
@@ -7071,14 +6961,15 @@
 /turf/open/floor/carpet,
 /area/station/security/prison)
 "ayF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "Bridge External Shutters"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/departments/aisat/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/fore)
 "ayG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -7111,14 +7002,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ayM" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	location = "Genetics and Xenobiology"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research/glass{
+	name = "Genetics Lab"
 	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "ayN" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -7288,9 +7182,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "azn" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/structure/chair,
+/obj/item/clothing/glasses/regular,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "azo" = (
 /obj/machinery/power/apc/auto_name/directional/east{
 	areastring = "/area/station/command/bridge"
@@ -7427,13 +7322,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "aAb" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/conveyor{
+	id = "atmosdelivery";
+	dir = 4
+	},
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Atmospherics"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "aAc" = (
 /obj/structure/disposalpipe/segment{
@@ -7601,11 +7502,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"aAA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
 "aAB" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -7655,15 +7551,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"aAF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "aAH" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -7676,9 +7563,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aAL" = (
-/obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/firedoor,
+/obj/structure/bed/medical/anchored,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "aAM" = (
@@ -8356,7 +8244,6 @@
 	pixel_x = -26;
 	pixel_y = 6
 	},
-/obj/structure/cable,
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -9155,9 +9042,15 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aFa" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/computer/records/security{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "aFb" = (
 /obj/machinery/light_switch{
 	pixel_y = 25
@@ -9268,23 +9161,12 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aFu" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/item/hand_labeler{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/paper_bin/carbon{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/item/paper_bin/carbon{
-	pixel_x = 9;
-	pixel_y = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/photocopier,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aFv" = (
@@ -10116,18 +9998,12 @@
 	},
 /area/station/hallway/primary/central)
 "aIe" = (
-/obj/structure/closet/secure_closet/security/science,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/south{
-	pixel_x = 28
+/obj/structure/chair/sofa/middle{
+	dir = 4
 	},
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Science Security Post"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/science)
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "aIg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -10506,17 +10382,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"aJY" = (
-/obj/structure/cable,
-/obj/machinery/newscaster{
-	pixel_x = 29;
-	pixel_y = 1
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
 "aKb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -10532,11 +10397,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aKf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "aKg" = (
 /obj/item/kirbyplants/organic/plant4,
 /turf/open/floor/iron/white/corner{
@@ -10687,13 +10552,9 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
-/obj/machinery/button/door/directional/south{
-	id = "north-atmos-shutters";
-	name = "Project Shutters";
-	req_access = list("atmospherics")
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "aKO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -10795,10 +10656,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "aLf" = (
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/science/ordnance/testlab)
 "aLi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -10810,13 +10672,14 @@
 "aLk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aLl" = (
-/obj/item/storage/belt/fannypack/yellow,
-/obj/structure/closet/secure_closet/quartermaster,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "aLn" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -10914,11 +10777,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "aLB" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "aLC" = (
@@ -11087,19 +10949,23 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aMe" = (
-/obj/structure/plasticflaps/opaque{
-	name = "Bounty Cubes"
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table,
+/obj/item/hand_labeler{
+	pixel_x = -8;
+	pixel_y = 5
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "BountyCubes"
+/obj/item/paper_bin/carbon{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/paper_bin/carbon{
+	pixel_x = 9;
+	pixel_y = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aMf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "CargoUnload";
@@ -11184,25 +11050,32 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aMv" = (
-/turf/closed/wall,
-/area/station/security/checkpoint/science)
+/obj/structure/table,
+/obj/item/paper_bin/carbon{
+	layer = 2.9
+	},
+/obj/item/pen,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "aMw" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "aMx" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/spawner/random/trash/grime,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aMy" = (
-/obj/structure/cable,
+/obj/structure/chair/sofa/left/brown,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aMA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11534,34 +11407,28 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "aNL" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
-"aNO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/science/explab)
 "aNQ" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aNT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/closed/wall,
-/area/station/maintenance/department/cargo)
+/obj/effect/spawner/random/trash/janitor_supplies,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "aNU" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aNV" = (
@@ -11581,9 +11448,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aOg" = (
 /obj/structure/chair,
@@ -11591,9 +11456,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aOh" = (
 /obj/structure/chair,
@@ -11602,9 +11465,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aOk" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -11818,11 +11679,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "aOT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
+/obj/machinery/recharge_station,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/cargo/storage)
 "aOU" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/lesser)
@@ -11833,20 +11693,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aOW" = (
-/obj/machinery/netpod,
-/obj/machinery/light/dim/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
-"aOZ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo Quartermaster's Office"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"aOZ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aPa" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -11874,15 +11730,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "aPh" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/random/directional/north,
-/obj/item/storage/box/mousetraps,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/sign/poster/contraband/pwr_game/directional/north,
+/obj/structure/chair/sofa/right/brown,
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo Bitrunning"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aPi" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/netpod,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aPn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12087,19 +11946,15 @@
 /obj/machinery/door/airlock/mining{
 	name = "Drone Bay"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/cargo/bitrunning/den)
 "aQa" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "aQf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -12123,13 +11978,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aQo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/landmark/start/bitrunner,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aQp" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aQr" = (
 /obj/structure/chair{
 	dir = 8
@@ -12399,65 +12255,61 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aRg" = (
-/obj/effect/landmark/start/cargo_technician,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
-"aRi" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"aRj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"aRl" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science)
-"aRn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
-"aRo" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
-"aRp" = (
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
-	pixel_x = 25
-	},
-/obj/structure/table,
-/obj/item/computer_disk{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/computer_disk{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/computer_disk{
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"aRq" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed,
+/area/station/cargo/bitrunning/den)
+"aRi" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"aRj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/mail_sorting/supply/qm_office,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/cargo/sorting)
+"aRl" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"aRn" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
+"aRo" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
+"aRp" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
+"aRq" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "aRs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12560,20 +12412,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
-"aRJ" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "aRL" = (
 /turf/closed/wall,
 /area/station/service/hydroponics)
@@ -12685,21 +12523,28 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "aSd" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aSe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/cargo/office)
-"aSf" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/computer/piratepad_control/civilian{
+	dir = 8;
+	pixel_y = -2
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/hallway/primary/central)
+"aSf" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "aSg" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -12717,7 +12562,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aSk" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aSr" = (
@@ -12878,7 +12724,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aSY" = (
-/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aSZ" = (
@@ -12887,9 +12733,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aTa" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "aTb" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
@@ -12915,22 +12765,50 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/monastery)
 "aTg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/effect/landmark/navigate_destination/cargo,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/cargo/sorting)
 "aTk" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "aTl" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/machinery/light/directional/north,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = 20
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 37
+	},
+/obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "aTm" = (
-/obj/machinery/suit_storage_unit/industrial/loader,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Kitchen";
+	location = "Med"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "aTo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12947,15 +12825,23 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aTs" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/structure/transit_tube/diagonal,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"aTv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/mining{
+	name = "Bitrunning Lounge"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
-"aTv" = (
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/cargo/bitrunning/den)
 "aTw" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -12977,9 +12863,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "aTB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Launch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "aTH" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -13171,43 +13062,40 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aUj" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"aUq" = (
+/obj/machinery/ai_slipper{
+	uses = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
+"aUs" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
+"aUu" = (
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/cargo/sorting)
+"aUv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
-"aUq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"aUs" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "QM #4"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
-"aUu" = (
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -9
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"aUv" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "aUw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13219,22 +13107,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aUz" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo Bay"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
-"aUA" = (
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"aUA" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aUC" = (
@@ -13533,12 +13415,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aVp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/structure/transit_tube/station/dispenser/flipped{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aVq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13818,38 +13702,25 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "aWs" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/north{
-	pixel_y = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/item/pen/red{
-	pixel_y = 7
-	},
-/obj/item/dest_tagger{
-	pixel_x = 9;
-	pixel_y = -1
-	},
-/obj/item/stamp{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/stamp/denied{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
+/turf/open/floor/iron/grimy,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "aWt" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aWu" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "aWw" = (
 /obj/effect/spawner/structure/window,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "aWz" = (
@@ -13859,9 +13730,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aWB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot,
+/obj/item/storage/box/mousetraps,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aWE" = (
@@ -14153,10 +14026,11 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "aXs" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	pixel_y = 1
+/obj/machinery/computer/cargo/request{
+	dir = 1
 	},
-/obj/machinery/modular_computer/preset/cargochat/cargo,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aXw" = (
@@ -14170,38 +14044,36 @@
 	},
 /obj/effect/turf_decal/bot,
 /mob/living/simple_animal/bot/mulebot,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aXy" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate/internals,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aXA" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/engineering/atmos/office)
 "aXB" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/engine,
-/area/station/science/explab)
-"aXC" = (
-/obj/machinery/light_switch/directional/west,
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard,
-/obj/item/airlock_painter/decal,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
+"aXC" = (
+/obj/machinery/airalarm/directional/east,
+/turf/closed/wall,
+/area/station/cargo/miningdock)
 "aXF" = (
 /obj/structure/chair{
 	dir = 4
@@ -14301,9 +14173,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aXV" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -14373,12 +14243,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aYh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "aYi" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -14458,6 +14327,9 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aYr" = (
@@ -14473,20 +14345,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aYw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
+/obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aYx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "QM #2"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "aYz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14500,7 +14365,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/space,
-/area/station/engineering/atmos)
+/area/space/nearstation)
 "aYE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -14708,6 +14573,9 @@
 "aZj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aZk" = (
@@ -14726,22 +14594,25 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aZo" = (
-/obj/structure/disposalpipe/junction/yjunction,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
-"aZq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "QM #3"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot,
+/obj/structure/closet/crate/medical,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"aZq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "aZv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -14807,19 +14678,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aZE" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/requests_console{
-	department = "Science";
-	name = "Science Requests Console";
-	pixel_y = 32
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "aZF" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
@@ -14907,9 +14771,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aZT" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -15041,19 +14903,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"baw" = (
-/obj/structure/sign/poster/random/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/aft)
 "bax" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "baB" = (
@@ -15066,18 +14919,15 @@
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
 "baD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baE" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/bot,
 /obj/machinery/light_switch/directional/south{
 	pixel_x = -8
 	},
@@ -15087,7 +14937,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baF" = (
-/obj/structure/table,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baJ" = (
@@ -15365,18 +15215,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bbA" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
-	c_tag = "Cargo Mining Dock"
+	c_tag = "Cargo Mining"
 	},
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
-/obj/machinery/computer/security/mining{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bbB" = (
@@ -15409,11 +15256,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "bbO" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bbP" = (
 /turf/closed/wall,
 /area/station/maintenance/disposal)
@@ -15579,10 +15425,8 @@
 /turf/open/floor/carpet/lone,
 /area/station/service/bar)
 "bcr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "bcs" = (
 /obj/item/clothing/shoes/sandal,
 /turf/open/floor/iron/dark,
@@ -15600,6 +15444,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/trash/energybar{
+	pixel_x = 10;
+	pixel_y = 12
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bcw" = (
@@ -15616,30 +15464,22 @@
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bcB" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/machinery/air_sensor/ordnance_burn_chamber,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "bcE" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcF" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
-"bcG" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/chair{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
 	},
+/turf/open/floor/iron/white,
+/area/station/science/explab)
+"bcG" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcI" = (
@@ -15651,31 +15491,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bcK" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/machinery/light/directional/west,
+/obj/machinery/computer/security/mining{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
-/obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bcS" = (
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bcV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/station/cargo/bitrunning/den)
 "bcX" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -15837,29 +15670,31 @@
 /area/station/cargo/miningdock)
 "bdJ" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdM" = (
-/mob/living/basic/mothroach{
-	desc = "That's mining's pet mothroach Aemilia. Affectionately known as the mini Darkheart they're quite sweet, offering weary miners reassurance after long days of carving hardened basalt and running from megafauna.";
-	name = "Aemilia"
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/east{
+	name = "Atmospherics Desk";
+	req_access = list("atmospherics")
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Security Door"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/lobby)
 "bdQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/effect/landmark/start/quartermaster,
+/obj/machinery/holopad,
+/obj/structure/chair/office,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "bdR" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/closed/wall,
+/area/station/medical/psychology)
 "bdS" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -15895,18 +15730,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"beb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "bec" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -16086,17 +15909,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "bez" = (
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 5
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/airlock_controller/incinerator_ordmix{
-	pixel_x = -4;
-	pixel_y = 27
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -6
 	},
 /turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/explab)
 "beA" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -16162,9 +15984,6 @@
 /area/station/science/robotics/mechbay)
 "beL" = (
 /obj/machinery/computer/order_console/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "beM" = (
@@ -16174,11 +15993,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "beN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "beO" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -16356,12 +16173,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bfC" = (
-/obj/machinery/conveyor/inverted{
-	dir = 5;
-	id = "CargoLoad"
+/obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "bfD" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -16374,29 +16194,20 @@
 /obj/item/shovel{
 	pixel_x = -5
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west{
-	pixel_y = 1
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bfH" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bfI" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "bfJ" = (
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bfK" = (
 /obj/docking_port/stationary{
@@ -16637,8 +16448,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bgB" = (
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/cargo/sorting)
 "bgC" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
@@ -16689,25 +16501,25 @@
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
 "bgK" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bgL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bgM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bgS" = (
@@ -16904,31 +16716,33 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining";
-	dir = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bht" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
+/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bhu" = (
 /obj/machinery/light/directional/south,
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bhv" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/bouldertech/refinery,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -17367,7 +17181,7 @@
 /turf/closed/wall/r_wall,
 /area/station/science/explab)
 "bjB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "bjF" = (
@@ -17425,26 +17239,18 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "bjT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/keycard_auth/directional/west,
-/obj/machinery/button/door{
-	id = "cmoprivacy";
-	name = "CMO Shutter Control";
-	pixel_x = -26;
-	pixel_y = 9;
-	req_access = list("cmo")
+/obj/machinery/fax{
+	fax_name = "Chief Medical Officer's Office";
+	name = "Chief Medical Officer's Fax Machine"
 	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Chief Medical Office";
-	network = list("ss13","medbay");
-	pixel_y = -22
-	},
+/obj/structure/table,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bjU" = (
@@ -17468,6 +17274,7 @@
 "bjY" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bjZ" = (
@@ -17514,8 +17321,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bkg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -17527,10 +17335,10 @@
 	c_tag = "Central Primary Hallway Medbay";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bkm" = (
@@ -17577,6 +17385,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "bkr" = (
+/obj/structure/showcase/horrific_experiment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "bks" = (
@@ -17595,10 +17404,15 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "bkv" = (
-/obj/machinery/atmospherics/components/binary/tank_compressor,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/screwdriver,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "bkw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -17648,7 +17462,7 @@
 	opacity = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "bkQ" = (
@@ -17679,15 +17493,24 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "bkW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 14
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/item/stack/sheet/glass{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/pipe_dispenser,
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bkX" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/yellow{
@@ -17730,9 +17553,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "bld" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/medical/medbay/lobby)
 "ble" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 1;
@@ -17774,15 +17600,6 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
-"blo" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
 "blp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -17898,14 +17715,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "blE" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/medical/virology)
 "blF" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -18020,11 +17836,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bmd" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/fore)
 "bmf" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -18059,19 +17875,13 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bmt" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/latex,
-/obj/item/surgical_drapes,
-/obj/structure/cable,
-/obj/item/stack/medical/bone_gel,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/structure/bed,
+/obj/item/bedsheet/cmo,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine)
 "bmv" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -18084,26 +17894,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bmx" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/noticeboard/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "bmy" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Kitchen";
-	location = "Med"
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -18249,13 +18048,9 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "bnc" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/station/engineering/atmos)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "bnd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18303,14 +18098,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bnu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/smartfridge/petri/preloaded,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "bnv" = (
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark,
@@ -18339,21 +18130,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bnE" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/light/directional/west,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "bnF" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "bnG" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -18382,11 +18169,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bnO" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Psychology Office";
+	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "bnP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18472,15 +18260,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
-"boc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "bod" = (
 /turf/closed/wall,
 /area/station/science/explab)
@@ -18549,11 +18328,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "boB" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/directional/north,
+/obj/machinery/defibrillator_mount/directional/north,
+/obj/item/stack/medical/gauze,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "boE" = (
 /obj/machinery/light/small/directional/south,
@@ -18572,10 +18353,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
-"boK" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "boL" = (
 /obj/item/toy/basketball,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -18587,6 +18364,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "boO" = (
@@ -18723,21 +18501,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bpi" = (
-/obj/structure/table,
-/obj/item/storage/medkit/o2{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/doppler_array,
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
+	pixel_x = 25
 	},
-/obj/item/storage/medkit/o2,
-/obj/item/storage/medkit/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "bpn" = (
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -18746,13 +18516,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "bpq" = (
-/obj/machinery/light/directional/north,
-/obj/structure/plaque/static_plaque/atmos{
-	pixel_y = 32
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "bpr" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -18775,11 +18542,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bpz" = (
-/obj/structure/chair/sofa/left,
-/obj/item/toy/plush/moth,
-/obj/structure/sign/poster/official/help_others/directional/north,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/structure/sink/directional/west,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bpD" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -18800,18 +18569,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "bpG" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
-"bpH" = (
-/obj/structure/table/glass,
-/obj/item/stack/medical/gauze,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/medical/medbay/central)
 "bpI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -18851,8 +18613,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "bpR" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -18870,23 +18632,29 @@
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "bpW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/cmo)
+"bpX" = (
+/obj/item/computer_disk/medical,
+/obj/item/computer_disk/medical,
+/obj/item/computer_disk/medical,
+/obj/structure/table,
+/obj/item/wrench/medical,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"bpX" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/command/heads_quarters/cmo)
 "bpY" = (
 /turf/closed/wall,
 /area/station/medical/chemistry)
@@ -18997,6 +18765,10 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
+/obj/machinery/camera/directional/east{
+	c_tag = "Server Room";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bqo" = (
@@ -19027,17 +18799,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bqr" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/fax{
-	fax_name = "Research Division";
-	name = "Research Division Fax Machine";
-	pixel_x = 1
-	},
-/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/medical/storage)
 "bqs" = (
 /turf/open/floor/iron/white,
 /area/station/science/explab)
@@ -19045,35 +18813,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bqv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bqw" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -19084,9 +18842,6 @@
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/iron/fifty,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
@@ -19099,15 +18854,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"bqA" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/cargo)
 "bqC" = (
 /obj/machinery/monkey_recycler,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -19266,16 +19012,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"brd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "brf" = (
 /obj/effect/spawner/atmos_canister/anesthetic_mix,
 /turf/open/floor/plating,
@@ -19290,26 +19026,36 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "brh" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/machinery/door/airlock/command{
+	name = "Chief Medical Officer's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/command/heads_quarters/cmo)
 "brj" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "brk" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/closet/crate,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/obj/machinery/computer/security/telescreen/ordnance{
+	dir = 4;
+	pixel_x = -27
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "brl" = (
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
@@ -19379,7 +19125,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/structure/showcase/horrific_experiment,
+/obj/machinery/fax{
+	fax_name = "Research Division";
+	name = "Research Division Fax Machine";
+	pixel_x = 1
+	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "brv" = (
@@ -19462,6 +19213,9 @@
 /area/station/science/explab)
 "brH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "brJ" = (
@@ -19584,24 +19338,23 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bsn" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
-"bsp" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/box/bodybags{
-	pixel_x = -6;
-	pixel_y = 6
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
+"bsp" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "Genetics and Xenobiology"
 	},
-/obj/item/storage/box/disks{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "bsq" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/mapping_helpers/broken_floor,
@@ -19640,85 +19393,38 @@
 "bsA" = (
 /turf/closed/wall,
 /area/station/medical/exam_room)
-"bsB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"bsC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "bsF" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
+/obj/structure/lattice,
+/obj/machinery/camera/directional/west{
+	c_tag = "Bridge External Access"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/turf/open/space/basic,
+/area/space/nearstation)
 "bsG" = (
 /obj/structure/table/glass,
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bsH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "bsI" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"bsJ" = (
-/obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bsK" = (
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bsL" = (
-/obj/structure/closet/secure_closet/security/med,
-/obj/item/radio/off,
-/obj/item/screwdriver,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/flora/bush/ferny/style_random,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "bsN" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -19866,44 +19572,39 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "btp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/structure/tank_dispenser,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "bts" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/closet/emcloset/anchored,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/meter,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "btt" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
-"btu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "btv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "btB" = (
@@ -19979,9 +19680,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "btS" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "btV" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/latex/nitrile,
@@ -19996,17 +19700,27 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "btY" = (
-/obj/machinery/button/door/directional/north{
-	id = "south-atmos-shutters";
-	name = "Project Shutters";
-	req_access = list("atmospherics")
+/obj/machinery/requests_console/directional/south{
+	department = "AI";
+	name = "AI Chamber Requests Console"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_y = -40
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "btZ" = (
-/obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light/small/directional/south,
+/obj/structure/closet/crate/freezer/food,
+/obj/item/reagent_containers/chem_pack,
+/obj/item/reagent_containers/chem_pack,
+/obj/item/organ/internal/heart,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bua" = (
@@ -20014,19 +19728,21 @@
 /turf/open/floor/carpet,
 /area/station/security/prison)
 "bub" = (
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/cmo)
-"buc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center"
+/obj/structure/table/glass,
+/obj/item/stack/medical/gauze{
+	pixel_x = -9;
+	pixel_y = 6
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/item/clothing/neck/stethoscope,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/command/heads_quarters/cmo)
 "bug" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
 	id = "Cell 1";
@@ -20046,21 +19762,22 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "buj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "CMO Office"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/cmo)
+/obj/structure/window,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "buk" = (
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/closed/wall/r_wall,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bul" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bum" = (
@@ -20136,15 +19853,11 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "buw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "bux" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -20153,8 +19866,8 @@
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
@@ -20174,63 +19887,49 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/bar)
-"buD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
-"buE" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
 "buF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/medical/medbay/lobby)
 "buH" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/structure/closet/secure_closet/security/med,
+/obj/item/radio/off,
+/obj/item/screwdriver,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "buJ" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "buK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/obj/structure/closet/secure_closet/cytology,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "buL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "buM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bva" = (
 /turf/closed/wall,
@@ -20261,19 +19960,10 @@
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
 /obj/machinery/light/directional/east,
-/obj/machinery/button/door{
-	id = "plumbing_shutters";
-	name = "Plumbing Shutter Control";
-	pixel_x = 25;
-	req_access = list("plumbing")
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch/directional/east{
-	pixel_y = 10
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvi" = (
@@ -20292,25 +19982,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"bvl" = (
-/obj/structure/sign/departments/exam_room,
-/turf/closed/wall,
-/area/station/medical/exam_room)
 "bvm" = (
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/flora/bush/large/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "bvn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/security/prison)
 "bvo" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8;
+	piping_layer = 2
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "bvw" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/research_and_development{
@@ -20365,6 +20052,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bvF" = (
@@ -20409,6 +20097,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bvN" = (
@@ -20418,14 +20107,18 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bvO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bvP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bvQ" = (
@@ -20437,16 +20130,19 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "bvS" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "bvT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/assembly/mousetrap/armed,
+/obj/machinery/door/window/left/directional/west{
+	name = "Research Division Delivery";
+	req_access = list("research")
+	},
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bvU" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/mecha_part_fabricator,
@@ -20470,18 +20166,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
-"bwc" = (
-/obj/machinery/chem_master,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/engine,
-/area/station/science/explab)
 "bwm" = (
-/turf/closed/wall,
-/area/station/maintenance/department/science)
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/disposal/incinerator)
 "bwn" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -20524,22 +20219,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bwu" = (
-/obj/machinery/door/airlock/medical{
-	name = "Surgical Theatres"
+/obj/machinery/mass_driver/ordnance,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/door/window/left/directional/west{
+	name = "Mass Driver Door";
+	req_access = list("ordnance")
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "bwv" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/iron/dark,
@@ -20549,8 +20239,6 @@
 	dir = 4;
 	name = "Air Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bwA" = (
@@ -20567,13 +20255,9 @@
 /area/station/medical/chemistry)
 "bwB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/medical,
-/obj/item/scalpel{
-	pixel_y = 12
+/obj/item/skub{
+	name = "medicinal skub"
 	},
-/obj/item/hemostat,
-/obj/item/cautery,
-/obj/item/hemostat,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bwC" = (
@@ -20581,6 +20265,10 @@
 /obj/item/bedsheet/medical,
 /obj/structure/curtain{
 	layer = 4.5
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay Fore Hall";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -20592,11 +20280,9 @@
 /turf/open/floor/grass,
 /area/station/medical/exam_room)
 "bwS" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/pipedispenser/disposal,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bwT" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
@@ -20609,12 +20295,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bwW" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
-	},
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "bxa" = (
 /obj/machinery/computer/department_orders/science{
 	dir = 4
@@ -20800,7 +20483,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bxy" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20810,13 +20492,17 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bxA" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay"
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "bxC" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Recreation";
@@ -20826,14 +20512,19 @@
 /turf/open/floor/carpet,
 /area/station/security/prison)
 "bxD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/kirbyplants/organic/plant11,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat External Starboard";
+	network = list("minisat")
+	},
+/turf/open/space,
+/area/space/nearstation)
 "bxF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bxG" = (
@@ -20848,20 +20539,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bxK" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/engine,
-/area/station/science/explab)
-"bxL" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Research Division Delivery";
-	req_access = list("research")
+/obj/machinery/door/window/left/directional/west{
+	name = "Monkey Pen";
+	req_access = list("genetics")
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/item/assembly/mousetrap/armed,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/structure/flora/grass/jungle,
+/mob/living/basic/butterfly,
+/turf/open/floor/grass,
+/area/station/science/genetics)
+"bxL" = (
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "bxM" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -20991,13 +20680,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "byg" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "byh" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -21023,15 +20708,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"byo" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/syringe,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "byp" = (
 /obj/machinery/cryo_cell,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -21050,18 +20726,26 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "byv" = (
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
+/obj/structure/table,
+/obj/item/storage/box/syringes{
+	pixel_y = 13;
+	pixel_x = -4
 	},
-/obj/item/reagent_containers/syringe,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/item/storage/box/beakers{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "byw" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/blue{
@@ -21070,8 +20754,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "byz" = (
@@ -21082,17 +20768,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "byA" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/latex,
-/obj/item/surgical_drapes,
-/obj/item/surgicaldrill,
-/obj/item/bonesetter,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -10;
+	pixel_y = 5
 	},
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "byC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -21151,12 +20835,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"byJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "byL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21236,6 +20914,7 @@
 	c_tag = "Research Division Secure Hallway"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "byX" = (
@@ -21254,49 +20933,57 @@
 /area/station/service/kitchen)
 "bza" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bzb" = (
-/obj/structure/closet/radiation,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/dark,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/component_printer,
+/turf/open/floor/engine,
 /area/station/science/explab)
 "bzc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle{
+	pixel_x = 7
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bzg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bzh" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -4;
-	pixel_y = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 8
 	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "bzi" = (
-/obj/structure/table,
-/obj/item/electropack,
-/obj/item/taperecorder,
-/obj/item/screwdriver,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/machinery/door/airlock/command{
+	id_tag = "CMOCell";
+	name = "Personal Examination Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bzj" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "bzk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -21441,7 +21128,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bzJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
 	},
@@ -21478,17 +21164,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bzT" = (
-/obj/machinery/computer/records/medical{
-	dir = 1
-	},
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bzV" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/flora/bush/grassy/style_random,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/stasis,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bzZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21500,20 +21184,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "bAg" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/medbay/central)
 "bAh" = (
 /obj/structure/frame/computer{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "bAi" = (
@@ -21580,18 +21264,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"bAu" = (
-/obj/machinery/mass_driver/ordnance,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/left/directional/west{
-	name = "Mass Driver Door";
-	req_access = list("ordnance")
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/science/ordnance)
 "bAv" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -21624,27 +21296,26 @@
 /turf/closed/wall,
 /area/station/science/ordnance/storage)
 "bAC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
-"bAD" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
-"bAE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"bAD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
+"bAE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/ordnance)
 "bAF" = (
 /turf/closed/wall,
 /area/station/science/ordnance)
@@ -21708,28 +21379,14 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/crew_quarters/bar)
 "bBe" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
-"bBf" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/item/cigbutt/cigarbutt,
+/obj/item/trash/chips,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bBg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center"
 	},
@@ -21737,14 +21394,16 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bBi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
+/obj/structure/chair,
+/obj/effect/mapping_helpers/mob_buckler,
+/mob/living/carbon/human/species/monkey{
+	name = "Bonbon"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -21837,14 +21496,15 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "bBy" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bBz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -21889,16 +21549,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bBJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/engineering/atmos/hfr_room)
 "bBK" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/firealarm/directional/west,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -21911,56 +21568,85 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bBN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/plaque,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Launch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bBO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/assembly/igniter{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -9
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bBP" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
+/obj/item/assembly/signaler{
+	pixel_y = 8
 	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron/dark,
+/obj/item/assembly/signaler{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/obj/item/holosign_creator/atmos{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bBQ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/item/transfer_valve{
+	pixel_x = -12
+	},
+/obj/item/transfer_valve{
+	pixel_x = -6
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 6
+	},
+/obj/item/transfer_valve{
+	pixel_x = 12
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Ordnance";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bBT" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/table,
-/obj/item/paper_bin/carbon{
-	layer = 2.9
-	},
-/obj/item/pen,
-/obj/structure/cable,
-/obj/machinery/status_display/supply{
-	dir = 4;
-	layer = 4;
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "bBU" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -22023,9 +21709,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bCg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "bCi" = (
 /obj/machinery/computer/atmos_control/nocontrol/incinerator,
 /obj/machinery/airalarm/directional/north,
@@ -22040,9 +21729,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/directional/west,
-/obj/machinery/vending/wallmed/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bCk" = (
@@ -22053,15 +21740,16 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bCl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
-"bCn" = (
-/obj/machinery/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_y = 5
 	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bCo" = (
@@ -22113,26 +21801,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bCx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/computer/records/medical{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/cmo{
-	dir = 1;
-	pixel_y = -26
-	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bCB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/brm,
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "bCC" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22189,16 +21866,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"bCM" = (
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
-/obj/machinery/research/anomaly_refinery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "bCN" = (
 /obj/structure/chair/comfy,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -22231,14 +21901,18 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bCU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Maintenance Starboard Aft";
+	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "bCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22253,27 +21927,32 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bDa" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bDb" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 1
+/obj/item/assembly/timer{
+	pixel_x = 5;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/item/assembly/timer{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/turf/open/floor/iron/dark,
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/obj/item/assembly/timer{
+	pixel_y = -4
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bDc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -22287,9 +21966,12 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "bDf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/chair/stool/directional/east,
+/obj/machinery/door/window/right/directional/west{
+	name = "Arena"
+	},
+/turf/open/floor/engine,
 /area/station/maintenance/department/medical)
 "bDg" = (
 /obj/effect/spawner/atmos_canister/air,
@@ -22314,22 +21996,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"bDv" = (
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/item/cautery,
-/obj/structure/table/glass,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "bDw" = (
 /obj/structure/table/glass,
-/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/mesh{
+	pixel_y = 7
+	},
 /obj/item/stack/medical/suture,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bDy" = (
@@ -22413,11 +22088,11 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "bDM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/computer/cargo{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "bDN" = (
 /obj/effect/spawner/atmos_canister/plasma,
 /obj/effect/turf_decal/delivery,
@@ -22432,7 +22107,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bDP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -22498,66 +22172,35 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"bDV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+"bDW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bDW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/cmo)
 "bDX" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/obj/machinery/door/poddoor/massdriver_ordnance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "bEa" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "bEb" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_x = 28;
-	pixel_y = 24
-	},
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/science)
-"bEc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"bEd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = 25;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/structure/sink/directional/west,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bEf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22600,13 +22243,21 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
 "bEs" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "surgerya";
-	name = "Privacy Shutter"
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/medical/surgery)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/records/medical{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "bEt" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -22651,49 +22302,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bEy" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 11
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
-"bEz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/machinery/chem_heater,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bEA" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/exam_room)
-"bEE" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/stasis,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bEF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/table/glass,
+/obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "bEN" = (
@@ -22793,18 +22412,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bEX" = (
-/obj/item/wrench,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/obj/effect/mapping_helpers/airalarm/link{
-	chamber_id = "ordnanceburn"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "bEY" = (
 /obj/effect/spawner/atmos_canister/oxygen,
 /obj/effect/turf_decal/bot,
@@ -22826,18 +22440,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bFb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"bFc" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "bFd" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -22849,86 +22454,65 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bFh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	pixel_y = 7;
+	pixel_x = 9
 	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/obj/item/stock_parts/cell/high,
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bFi" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -9;
-	pixel_y = 6
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock"
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 8;
-	pixel_y = 9
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 24;
+	req_access = list("virology")
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 9;
-	pixel_y = -2
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-viro";
+	id_tag = "viro-access"
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/obj/item/raw_anomaly_core/random{
-	pixel_y = 9
-	},
-/obj/item/raw_anomaly_core/random,
 /turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bFj" = (
-/obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/area/station/medical/virology)
 "bFk" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/ordnance,
-/obj/item/analyzer,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/pipe_dispenser,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/holosign_creator/atmos{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bFl" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bFn" = (
-/obj/machinery/computer/records/security{
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Lab";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/science)
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal/directional/north,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bFp" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4
-	},
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_x = -24
-	},
-/turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "bFq" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -22941,44 +22525,38 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bFr" = (
-/obj/machinery/door/poddoor/incinerator_ordmix,
-/obj/structure/sign/warning/fire/directional/north,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
-"bFs" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
 	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating,
-/area/station/science/ordnance)
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Ordnance Launch";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "bFu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bFx" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Monkey Pen";
-	req_access = list("genetics")
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "bFy" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Monkey Pen";
-	req_access = list("genetics")
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "bFB" = (
 /obj/item/newspaper,
 /turf/open/floor/plating,
@@ -23016,39 +22594,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"bFJ" = (
-/mob/living/carbon/human/species/monkey,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
 "bFK" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "bFL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/medical/virology)
-"bFM" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/obj/structure/window/reinforced/spawner/directional/south,
+/mob/living/basic/chicken{
+	name = "Killer Cluck"
 	},
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/fuel_input,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
+"bFM" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "atmos_project";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "bFO" = (
@@ -23058,9 +22621,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "bFP" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/structure/table/glass,
+/obj/item/flashlight/pen,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/lipstick/black,
+/obj/item/reagent_containers/pill/morphine,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine)
 "bFS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -23099,219 +22667,95 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "bGf" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	pixel_x = -30
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/structure/table,
-/obj/item/computer_disk/quartermaster,
-/obj/item/clipboard,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/coin/silver,
-/obj/item/stamp/head/qm,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "bGg" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
-"bGi" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination{
-	location = "Genetics"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"bGi" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "bGj" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
-"bGk" = (
-/obj/machinery/light/directional/south,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
-"bGl" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
-"bGm" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/structure/disposalpipe/trunk{
+/area/station/science/xenobiology)
+"bGo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bGn" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/igniter{
-	pixel_x = -9;
-	pixel_y = -2
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bGo" = (
-/obj/item/assembly/signaler{
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/holosign_creator/atmos{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bGp" = (
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/camera/directional/south{
-	c_tag = "Ordnance Lab Port";
-	network = list("ss13","rd")
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bGq" = (
-/obj/item/assembly/timer{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/assembly/timer{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/item/assembly/timer,
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
-"bGr" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/station/engineering/atmos)
-"bGs" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Experimentation Lab Testing Zone";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
-"bGt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
+"bGr" = (
+/obj/machinery/computer/atmos_control/mix_tank{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"bGs" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/engine,
+/area/station/science/explab)
+"bGt" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "bGu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bGv" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
-/turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bGw" = (
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/station/medical/medbay/central)
 "bGx" = (
-/obj/machinery/igniter/incinerator_ordmix,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "bGy" = (
-/obj/machinery/door/poddoor/incinerator_ordmix,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/green/visible,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "bGB" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/light/directional/south,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "bGD" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -23350,29 +22794,30 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bGK" = (
-/obj/structure/closet/boxinggloves,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "bGL" = (
-/obj/structure/closet/masks,
-/obj/item/food/deadmouse,
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Office Maintenance"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/maintenance/department/cargo)
 "bGM" = (
-/obj/machinery/vending/cigarette,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bGO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/carbon/human/species/monkey,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/virology)
 "bGT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23393,14 +22838,9 @@
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "bGW" = (
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"bGZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "bHf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -23408,7 +22848,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bHh" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23489,8 +22929,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "bHq" = (
-/turf/open/floor/plating/airless,
-/area/station/ai_monitored/aisat/exterior)
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnancefreezer"
+	},
+/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "bHr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -23525,63 +22971,41 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"bHv" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/computer/security/telescreen/ordnance{
-	dir = 4;
-	pixel_x = -27
-	},
-/obj/structure/closet/crate,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
 "bHw" = (
 /obj/structure/sign/warning/no_smoking/directional/south,
-/obj/effect/spawner/atmos_canister/air,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "bHy" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
-"bHz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/corner{
+"bHA" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = 24;
-	pixel_y = 7
-	},
-/obj/machinery/button/door/directional/east{
-	id = "ordnanceaccess";
-	pixel_y = -6
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"bHA" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/binary/pump{
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
+"bHC" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/binary/tank_compressor{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/station/science/ordnance/burnchamber)
-"bHC" = (
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "bHD" = (
-/obj/machinery/door/poddoor/incinerator_ordmix,
-/obj/structure/sign/warning/fire/directional/south,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/obj/effect/landmark/start/chief_medical_officer,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "bHE" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23621,62 +23045,48 @@
 /turf/open/floor/carpet,
 /area/station/security/prison)
 "bHP" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
-"bHQ" = (
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
-"bHR" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
-"bHS" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"bHT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
-"bHU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/mail_sorting/science/genetics,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"bHY" = (
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"bIa" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/computer/crew{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
-"bIb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/area/station/science/genetics)
+"bHQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"bHR" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"bHT" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/area/station/medical/exam_room)
+"bHU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Airlock";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"bHY" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/vending/assist,
+/turf/open/floor/engine,
+/area/station/science/explab)
+"bIa" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "bId" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/status_display/evac{
@@ -23744,19 +23154,10 @@
 	location = "Sci5"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bIE" = (
 /obj/effect/spawner/atmos_canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/station/science/ordnance/storage)
-"bIF" = (
-/obj/structure/sign/poster/random/directional/east,
-/obj/effect/spawner/atmos_canister/air,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
@@ -23772,13 +23173,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "bII" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "bIL" = (
 /obj/structure/filingcabinet/security,
 /obj/machinery/airalarm/directional/east,
@@ -23788,13 +23190,15 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "bIM" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "ordnanceaccess";
-	name = "Ordnance Access"
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/components/binary/pump/off/pink/visible{
+	dir = 1
+	},
+/obj/structure/sign/warning/hot_temp/directional/west,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "bIN" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
@@ -23854,45 +23258,57 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bJa" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "bJb" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "bJc" = (
-/obj/structure/chair/comfy/black,
-/obj/item/trash/pistachios,
+/obj/item/stack/spacecash/c10,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/area/station/maintenance/department/medical)
 "bJd" = (
-/obj/structure/chair/comfy/black,
-/obj/item/stack/spacecash/c100,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay Surgery";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "bJe" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "bJf" = (
-/obj/structure/chair/comfy/black,
-/obj/item/cigbutt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/extinguisher,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bJg" = (
-/obj/item/trash/popcorn,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bJh" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "bJi" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet,
@@ -23901,16 +23317,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"bJk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "bJm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -23922,25 +23328,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"bJE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/tank_dispenser,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"bJF" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/science/ordnance)
 "bJG" = (
 /obj/item/radio/intercom/prison/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -23965,10 +23352,10 @@
 /area/station/hallway/primary/aft)
 "bJJ" = (
 /obj/structure/sign/poster/random/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/kirbyplants/organic/plant18{
 	layer = 3
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "bJL" = (
@@ -24003,31 +23390,34 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "bJQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/incinerator_vent_ordmix{
+	pixel_y = -27;
+	pixel_x = -7
+	},
+/obj/machinery/button/ignition/incinerator/ordmix{
+	pixel_y = -27;
+	pixel_x = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bJR" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/computer/atmos_control/ordnancemix{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "bJS" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "bJT" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -24100,40 +23490,34 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bKh" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Arena"
-	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "bKi" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/basic/chicken{
-	name = "Bloodthirsty Peckins"
-	},
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bKj" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bKk" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/engine,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bKl" = (
-/obj/item/stack/medical/gauze,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bKm" = (
-/obj/structure/light_construct{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bKn" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -24149,10 +23533,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "bKp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "bKq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -24161,15 +23545,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "bKr" = (
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+/obj/structure/closet/l3closet/virology,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/virology)
 "bKt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -24177,24 +23562,22 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bKA" = (
-/obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bKG" = (
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/item/cautery,
-/obj/structure/table/glass,
-/obj/machinery/light/directional/east,
-/obj/item/blood_filter,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "bKH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/start/assistant,
@@ -24211,13 +23594,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bKK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bKM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -24230,7 +23613,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bKP" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Fitness"
@@ -24239,16 +23622,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bKR" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science)
-"bKS" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
-/area/station/security/checkpoint/science)
+/area/station/engineering/atmos)
+"bKS" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -24257,48 +23639,52 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bKU" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos{
-	name = "Ordnance Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/dna_infuser,
+/obj/item/infuser_book,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "bKV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bKW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/pipedispenser,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bKY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bKZ" = (
+/obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"bKY" = (
+/obj/item/assembly/prox_sensor{
+	pixel_x = -9;
+	pixel_y = 11
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/obj/item/raw_anomaly_core/random{
+	pixel_y = 9
+	},
+/obj/item/raw_anomaly_core/random,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
+"bKZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "bLa" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -24328,9 +23714,12 @@
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "bLf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/maintenance{
+	name = "Ordnance Lab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
-/area/station/science/ordnance/burnchamber)
+/area/station/maintenance/department/science/xenobiology)
 "bLh" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation"
@@ -24362,26 +23751,47 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bLq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/genetics)
-"bLt" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/machinery/shower/directional/east{
+	name = "emergency shower"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"bLt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "bLu" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "bLv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/area/station/science/ordnance/storage)
 "bLx" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/engine,
+/obj/structure/mop_bucket,
+/obj/item/mop,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bLy" = (
 /obj/machinery/door/airlock/grunge{
@@ -24403,15 +23813,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
-"bLC" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "bLE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -24434,21 +23835,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"bLL" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/closet/l3closet,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"bLM" = (
-/obj/machinery/computer/operating,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "bLO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24458,122 +23844,99 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bLP" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "bLR" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating,
 /area/station/engineering/lobby)
 "bLS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bLT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "bLU" = (
-/obj/machinery/airalarm/directional/east,
-/obj/item/kirbyplants/organic/applebush,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
 /area/station/engineering/lobby)
 "bLV" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light/directional/west,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the turbine vent.";
+	dir = 4;
+	name = "turbine vent monitor";
+	network = list("turbine");
+	pixel_x = -29
+	},
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/aft)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/disposal/incinerator)
 "bLW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "bLX" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bLY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bLZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bMa" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	name = "Atmos RC";
-	pixel_y = 30
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bMb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics Fore"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bMc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/meter,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bMd" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"bMb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Mix to Distro"
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"bMc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"bMd" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bMf" = (
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -24582,12 +23945,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bMh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "atmos_project";
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bMi" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/airless,
@@ -24601,17 +23967,14 @@
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "bMl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/effect/landmark/navigate_destination/cargo,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
-"bMm" = (
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/area/station/hallway/primary/central)
 "bMn" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer{
 	dir = 1
@@ -24657,22 +24020,34 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bMA" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/machinery/light/directional/south,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bMB" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bMC" = (
-/obj/item/stack/spacecash/c10,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "Bridge External Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/area/station/maintenance/fore)
 "bMD" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bME" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -24681,6 +24056,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "bMG" = (
@@ -24691,62 +24067,50 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "bMK" = (
-/obj/structure/table/glass,
-/obj/machinery/firealarm/directional/south,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/structure/table,
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/item/storage/box/beakers{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/item/storage/medkit/o2,
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/item/storage/box/syringes{
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bMM" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
-"bMN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/line,
+/obj/structure/closet/l3closet,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"bMN" = (
+/obj/machinery/defibrillator_mount/directional/south,
+/obj/structure/bed/medical/anchored,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "bMT" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/hallway/primary/aft)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "bMU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
 "bMV" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bMW" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/item/kirbyplants/organic/applebush,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bMX" = (
@@ -24762,76 +24126,66 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bMZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/conveyor_switch{
-	id = "atmosdeliver";
-	name = "Atmos Delivery";
-	pixel_y = 9
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bNa" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Atmospherics Delivery";
-	req_access = list("atmospherics")
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bNb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/hfr_room)
 "bNc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bNg" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air to Distro"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bNh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bNj" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/sink/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bNl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/directional/west,
-/obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"bNn" = (
-/obj/machinery/computer/atmos_control/mix_tank{
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
+"bNn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "bNo" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
 	dir = 8
@@ -24839,8 +24193,10 @@
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "bNp" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/area/station/science/explab)
 "bNq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -24858,9 +24214,9 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/asteroid/monastery)
 "bNt" = (
-/obj/effect/spawner/random/trash/janitor_supplies,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bNu" = (
 /obj/structure/displaycase/trophy,
 /obj/machinery/light/directional/east,
@@ -24903,32 +24259,35 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "bNF" = (
-/obj/item/stack/medical/suture,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bNG" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bNH" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "bNI" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/mob/living/basic/chicken{
-	name = "Killer Cluck"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Incinerator"
 	},
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bNJ" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Arena"
-	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/engine,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bNK" = (
 /obj/structure/grille/broken,
@@ -24939,7 +24298,6 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/cup/beaker,
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "bNM" = (
@@ -24951,31 +24309,18 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "bNO" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
-"bNP" = (
-/obj/item/skub{
-	name = "medicinal skub"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/cigbutt/cigarbutt,
-/obj/item/trash/chips,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bNQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"bNR" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
-	},
-/obj/effect/spawner/random/entertainment/drugs,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "bNS" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -24994,10 +24339,12 @@
 /turf/open/floor/grass,
 /area/station/medical/exam_room)
 "bNW" = (
-/obj/machinery/light/small/directional/north,
-/obj/item/wrench/medical,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "bNX" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -25021,46 +24368,35 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"bOc" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/aft)
-"bOd" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Aft Primary Hallway Atmospherics";
-	start_active = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/structure/table,
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
-/turf/open/floor/iron,
 /area/station/engineering/lobby)
-"bOe" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/modular_computer/preset/cargochat/engineering{
-	dir = 8
+"bOc" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
+"bOd" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/disks{
+	pixel_y = 11;
+	pixel_x = -6
 	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
+"bOe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bOf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
 "bOg" = (
@@ -25072,21 +24408,25 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bOh" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste In"
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bOj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/hfr_room)
 "bOl" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -25108,10 +24448,12 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "bOp" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bOq" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
@@ -25120,15 +24462,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bOt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
 "bOu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25149,16 +24482,23 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bOz" = (
-/obj/structure/chair/comfy/black{
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "QM #4"
+	},
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"bOA" = (
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
-"bOA" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "bOB" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -25168,16 +24508,28 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "bOE" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen/red,
+/obj/item/stack/medical/gauze,
+/obj/machinery/light/small/directional/east,
+/obj/item/hand_labeler,
+/obj/item/book/manual/wiki/infections,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bOF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bOG" = (
@@ -25191,15 +24543,15 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bOI" = (
-/obj/structure/sign/poster/official/love_ian,
-/turf/closed/wall,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "bOK" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -25212,39 +24564,39 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bOL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/station/engineering/lobby)
-"bOM" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"bOM" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bON" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
-	name = "Atmospherics Desk";
-	req_access = list("atmospherics")
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "bOO" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Monitoring"
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bOP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste In"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bOQ" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -25252,26 +24604,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bOS" = (
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "bOV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bOW" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "north-atmos-shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -25289,9 +24641,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "bPa" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bPb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -25300,10 +24656,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bPc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/transit_tube/horizontal,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bPd" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
@@ -25328,8 +24684,14 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "bPl" = (
-/turf/open/space/basic,
-/area/station/science/ordnance/burnchamber)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "bPn" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/iron/dark,
@@ -25340,19 +24702,16 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "bPp" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/area/station/ai_monitored/turret_protected/ai)
 "bPq" = (
-/obj/item/trash/chips,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "bPr" = (
-/obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "bPy" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
@@ -25390,69 +24749,52 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bPH" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bPI" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/conveyor{
-	id = "atmosdelivery"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	location = "Atmospherics"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bPJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bPK" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Engineering Lobby";
-	name = "Engineering Lobby Fax Machine"
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 11
+	},
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/wrench{
+	pixel_x = -12
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"bPL" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "bPM" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bPN" = (
-/obj/machinery/computer/atmos_control{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/conveyor_switch{
+	id = "atmosdeliver";
+	name = "Atmos Delivery";
+	pixel_y = 9
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bPO" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
@@ -25461,56 +24803,24 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "bPP" = (
-/obj/machinery/shower/directional/west,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/office)
 "bPQ" = (
 /turf/closed/wall,
 /area/station/engineering/atmos)
 "bPR" = (
-/obj/machinery/button/door/directional/west{
-	id = "north-atmos-shutters";
-	name = "Project Shutters";
-	req_access = list("atmospherics")
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
-"bPS" = (
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "bPT" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "bPU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bPW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
@@ -25573,12 +24883,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/library)
-"bQj" = (
-/mob/living/carbon/human/species/monkey,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
 "bQl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -25689,15 +24993,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bQB" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bQC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Eng3";
@@ -25706,25 +25011,26 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bQD" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bQF" = (
-/obj/structure/tank_dispenser,
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bQG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bQH" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -25752,13 +25058,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bQM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bQN" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 1
@@ -25789,13 +25091,9 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bQS" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/item/clothing/gloves/latex,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "bQY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -25916,10 +25214,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bRr" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bRs" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -25962,11 +25260,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "bRw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "bRx" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
@@ -26123,7 +25421,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "bRX" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -26148,15 +25446,20 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/door/window/left/directional/west{
+	name = "Atmospherics Delivery";
+	req_access = list("atmospherics")
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bSc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/atmos,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/office)
 "bSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -26165,9 +25468,12 @@
 /area/station/engineering/atmos)
 "bSe" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/sink/directional/east,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/machinery/door/airlock/maintenance{
+	name = "Genetics Lab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "bSf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26180,10 +25486,10 @@
 /turf/open/floor/iron,
 /area/station/security)
 "bSg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/obj/item/wrench,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/suit_storage_unit/industrial/loader,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "bSh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26220,8 +25526,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bSn" = (
-/obj/structure/closet/secure_closet/cytology,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bSo" = (
 /obj/machinery/disposal/bin,
@@ -26230,12 +25538,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"bSp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/virology)
 "bSq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/meter/monitored/layer4,
@@ -26258,6 +25560,7 @@
 "bSu" = (
 /obj/item/broken_bottle,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bSv" = (
@@ -26359,13 +25662,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bSM" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bSN" = (
 /obj/structure/sign/departments/engineering/directional/south,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bSO" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -26378,7 +25681,7 @@
 "bSP" = (
 /obj/structure/sign/departments/engineering/directional/south,
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/recharge_station,
+/obj/item/kirbyplants/organic/plant2,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bSQ" = (
@@ -26403,16 +25706,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bSS" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Atmospherics Project Room"
+/obj/structure/lattice,
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat External Fore";
+	network = list("minisat")
 	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/space,
+/area/space/nearstation)
 "bST" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/hfr_room)
@@ -26451,9 +25751,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "bTa" = (
-/obj/machinery/smartfridge/petri/preloaded,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bTb" = (
 /obj/machinery/atmospherics/components/tank/air{
@@ -26476,7 +25778,6 @@
 "bTf" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bTg" = (
@@ -26615,6 +25916,7 @@
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bTz" = (
@@ -26689,31 +25991,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"bTJ" = (
-/obj/item/trash/tray,
-/obj/item/trash/energybar,
-/obj/item/trash/energybar{
-	pixel_x = 10;
-	pixel_y = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "bTK" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/belt/utility,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/testlab)
 "bTL" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
@@ -26726,37 +26006,28 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "bTM" = (
+/obj/effect/landmark/carpspawn,
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+/turf/open/space/basic,
+/area/space/nearstation)
+"bTN" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/space,
-/area/station/engineering/atmos)
-"bTN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bTO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "bTP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bTQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26764,25 +26035,23 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bTR" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/effect/landmark/start/ai,
+/obj/machinery/newscaster/directional/south,
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = -43
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bTS" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/item/stack/medical/suture,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/maintenance/department/medical)
 "bTT" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTU" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
@@ -26960,20 +26229,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bUr" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/glass,
-/obj/item/stack/rods/fifty,
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "bUt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26986,12 +26244,13 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bUv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "incinerator mix pump"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "bUw" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark,
@@ -27012,6 +26271,7 @@
 	},
 /obj/machinery/space_heater,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bUz" = (
@@ -27242,7 +26502,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bVe" = (
-/obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
@@ -27252,32 +26511,23 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bVf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bVg" = (
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "CMO Maintenance"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/modular_computer/preset/id{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bVk" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "bVl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
@@ -27322,7 +26572,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bVv" = (
@@ -27536,24 +26785,26 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bVW" = (
-/obj/structure/fireaxecabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/window/reinforced/spawner/directional/west,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "bVY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/decal/cleanable/ash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bWa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bWb" = (
-/obj/effect/spawner/random/entertainment/drugs,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/cold_temp/directional/south,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "bWc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -27840,10 +27091,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bWQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/plating,
-/area/station/science/ordnance)
+/obj/machinery/shower/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bWR" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -27857,19 +27116,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/obj/structure/table,
-/obj/item/storage/box/shipping{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/multitool{
-	pixel_x = 8;
-	pixel_y = -4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/autolathe,
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bWV" = (
@@ -27984,14 +27237,6 @@
 /obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"bXr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "bXs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -28000,18 +27245,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "bXu" = (
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Launch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/closed/wall/r_wall,
 /area/station/science/ordnance)
 "bXv" = (
 /obj/machinery/conveyor{
@@ -28022,13 +27257,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bXw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Experimentation Lab South";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "bXy" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
@@ -28053,20 +27291,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bXC" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "bXD" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "bXE" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,
@@ -28104,11 +27337,9 @@
 /turf/closed/wall/mineral/iron,
 /area/station/service/library)
 "bXU" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/closet/cardboard,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bXV" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -28208,22 +27439,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "bYs" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/computer/department_orders/engineering{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/lobby)
-"bYt" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 11
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/engineering/atmos)
 "bYu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/structure/cable,
@@ -28440,20 +27661,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bZe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/structure/sign/departments/exam_room/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "bZf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -28469,11 +27680,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bZh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window,
+/obj/structure/sign/departments/exam_room,
+/turf/open/floor/plating,
 /area/station/medical/medbay/central)
 "bZi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28585,6 +27794,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bZL" = (
@@ -28716,6 +27926,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/structure/sign/poster/official/safety_eye_protection/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cau" = (
@@ -28741,18 +27952,34 @@
 "caw" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 3
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = -6;
+	pixel_x = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cax" = (
 /obj/structure/table,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/apc,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
+/obj/item/electronics/airlock{
+	pixel_y = 8
+	},
+/obj/item/electronics/airlock{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/electronics/apc{
+	pixel_x = 2
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -14
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "caz" = (
@@ -28827,9 +28054,13 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "caQ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/open/space,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "caS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28951,6 +28182,7 @@
 "cbo" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cbp" = (
@@ -29004,10 +28236,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "cbF" = (
-/obj/machinery/computer/order_console/bitrunning,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/item/storage/belt/fannypack/yellow,
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "cbK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -29151,8 +28384,8 @@
 "ccj" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 4
+	pixel_x = 8;
+	pixel_y = 10
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2
@@ -29164,7 +28397,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 2;
-	pixel_y = 4
+	pixel_y = 10
 	},
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -2
@@ -29180,29 +28413,31 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ccn" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/area/station/science/explab)
 "cco" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/station/science/ordnance/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ccp" = (
 /obj/effect/spawner/atmos_canister/plasma,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/structure/sign/warning/chem_diamond/directional/north,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "ccs" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/machinery/door/poddoor/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "ccu" = (
 /obj/structure/chair{
 	dir = 8
@@ -29229,7 +28464,6 @@
 "ccJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/contraband/random/directional/west,
-/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ccL" = (
@@ -29328,10 +28562,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cdo" = (
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/station/maintenance/department/medical)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "cdp" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -29532,19 +28765,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ceb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "cec" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/shower/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/structure/sign/poster/official/download/directional/south,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "cee" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	name = "Virology Waste to Space"
@@ -29574,25 +28806,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"cel" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "cen" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/trophy{
@@ -30066,9 +29279,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/monastery)
 "cgO" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "cgP" = (
 /obj/structure/transit_tube,
 /turf/open/floor/plating/airless,
@@ -30128,9 +29344,8 @@
 /turf/open/floor/iron,
 /area/station/service/chapel/monastery)
 "chf" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "chi" = (
 /obj/structure/flora/bush/pointy/style_random,
@@ -30404,13 +29619,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ciJ" = (
-/obj/machinery/computer/pandemic,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "ciK" = (
 /obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/carpet,
@@ -30458,29 +29669,25 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/chapel/monastery)
 "ciZ" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/machinery/camera/directional/west{
-	c_tag = "Genetics Monkey Pen Fore";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/light/small/directional/west,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "cje" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "cjf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -30622,9 +29829,11 @@
 /turf/open/floor/iron/checker,
 /area/station/service/chapel/monastery)
 "ckg" = (
-/obj/effect/spawner/atmos_canister/air,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "ckh" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -30684,20 +29893,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
-"ckz" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = -32
-	},
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "ckA" = (
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants/portaseeder,
@@ -30830,13 +30025,11 @@
 	},
 /area/station/service/chapel)
 "cld" = (
-/obj/structure/sink/directional/west,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/storage)
 "clf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
@@ -30862,9 +30055,9 @@
 /turf/closed/wall/mineral/iron,
 /area/station/service/chapel/asteroid/monastery)
 "clm" = (
-/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "cln" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -30932,11 +30125,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
-"clK" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "clL" = (
 /turf/closed/wall,
 /area/station/tcommsat/computer)
@@ -31023,6 +30211,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"cme" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "cmf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -31199,13 +30391,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cmA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "cmB" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -31411,8 +30596,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cnD" = (
-/turf/open/space/basic,
-/area/station/ai_monitored/aisat/exterior)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "cnE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31430,9 +30616,8 @@
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "cnH" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/station/ai_monitored/aisat/exterior)
+/turf/open/floor/plating/airless,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "cnJ" = (
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/iron,
@@ -31774,15 +30959,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
-"cpA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "cpB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -31883,13 +31063,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cpX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "cpY" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/disposal/bin,
@@ -31909,28 +31090,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cqc" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/pale/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/grass/brown,
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/structure/flora/rock/pile/icy,
-/obj/structure/flora/bush/large/style_random{
-	pixel_y = -8
+/obj/machinery/chem_master,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/structure/flora/bush/reed/style_random,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
-"cqd" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/defibrillator_mount/directional/north,
-/obj/machinery/stasis,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/turf/open/floor/engine,
+/area/station/science/explab)
 "cqe" = (
 /obj/effect/turf_decal/plaque,
 /obj/machinery/navbeacon{
@@ -31974,20 +31139,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cqm" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "cqp" = (
-/obj/machinery/medical_kiosk,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cqs" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
+/obj/machinery/suit_storage_unit/cmo,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/command/heads_quarters/cmo)
 "cqt" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Research Division Hallway"
@@ -32022,7 +31187,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/engineering/lobby)
 "cqy" = (
 /obj/structure/rack{
 	icon = 'icons/obj/fluff/general.dmi';
@@ -32037,38 +31202,32 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cqA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/cargo/sorting)
 "cqD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cqE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/structure/cable,
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cqG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/pipedispenser/disposal,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/window,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "cqH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	name = "The Roosterdome"
 	},
-/mob/living/basic/cockroach,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/maintenance/department/medical)
 "cqI" = (
 /obj/structure/chair{
 	dir = 8
@@ -32112,12 +31271,19 @@
 /turf/open/floor/iron,
 /area/station/service/chapel/monastery)
 "crd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/landmark/start/depsec/medical,
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "cre" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -32194,19 +31360,17 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "cry" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/extinguisher,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/transit_tube,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "crz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "crB" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/closet/boxinggloves,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "crC" = (
@@ -32282,11 +31446,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "csh" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/hobo_squat,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/department/engine)
 "csk" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -32328,7 +31490,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "csv" = (
@@ -32388,10 +31549,6 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"ctb" = (
-/obj/structure/sign/poster/official/corporate_perks_vacation,
-/turf/closed/wall,
-/area/station/maintenance/department/engine)
 "cth" = (
 /obj/structure/chair{
 	dir = 8
@@ -32407,13 +31564,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "ctt" = (
-/mob/living/basic/pet/dog/corgi,
-/obj/structure/water_source/puddle,
-/obj/structure/flora/bush/reed/style_random{
-	pixel_y = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology Isolation A";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "ctu" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Lounge"
@@ -32448,11 +31608,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "ctQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/structure/table,
+/obj/item/storage/dice,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ctS" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
@@ -32598,16 +31757,12 @@
 /turf/open/floor/iron,
 /area/station/service/chapel/monastery)
 "cuL" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Cargo Office"
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/item/storage/box/shipping,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "cuM" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -32644,19 +31799,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "cuX" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal/directional/north,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "cuY" = (
-/obj/structure/cable,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "cuZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32685,14 +31836,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "cvf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/conveyor{
-	id = "CargoLoad";
-	dir = 8
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "cvg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32806,12 +31957,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"cvV" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/dna_infuser,
-/obj/item/infuser_book,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "cwa" = (
 /turf/closed/wall/mineral/iron,
 /area/station/maintenance/department/chapel/monastery)
@@ -32893,9 +32038,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
 "cwz" = (
-/obj/structure/grille/broken,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/maintenance/department/medical)
 "cwA" = (
 /turf/open/floor/plating,
@@ -33009,14 +32152,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "cxJ" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
-/obj/machinery/computer/cargo/request{
-	dir = 8
+/obj/machinery/newscaster/directional/west,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
 	},
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "cxK" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Library Starboard";
@@ -33035,10 +32177,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "cxM" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "cxX" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern{
@@ -33141,12 +32282,13 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "czd" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/chair/office{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/mob/living/simple_animal/pet/gondola/russ/camdola,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "cze" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -33285,8 +32427,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAi" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/engine,
 /area/station/maintenance/department/medical)
 "cAj" = (
 /obj/machinery/door/airlock/grunge{
@@ -33368,15 +32510,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cAS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Isolation A";
-	network = list("ss13","medbay")
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -6
 	},
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "cAU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33487,11 +32631,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "cBK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/bed/dogbed/runtime,
+/mob/living/basic/pet/cat/runtime,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/command/heads_quarters/cmo)
 "cBL" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing"
@@ -33561,32 +32711,21 @@
 /turf/open/floor/iron/dark,
 /area/station/security)
 "cCT" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "cCU" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cCV" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/wrench,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 15
-	},
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cCW" = (
@@ -33595,15 +32734,17 @@
 /turf/open/floor/iron/checker,
 /area/station/service/chapel/monastery)
 "cCY" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo Warehouse"
-	},
-/obj/structure/closet/cardboard,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "cDa" = (
-/turf/closed/wall,
-/area/station/cargo/warehouse)
+/obj/machinery/conveyor{
+	id = "CargoLoad";
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "cDy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -33632,6 +32773,13 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
+"cHp" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/piratepad/civilian,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cHS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firing Range"
@@ -33641,30 +32789,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "cIe" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/mob/living/simple_animal/pet/gondola/russ/camdola,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "cJZ" = (
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "cKF" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
-"cLu" = (
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/modular_computer/preset/cargochat/medical{
 	dir = 8
 	},
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
+"cLu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "cMl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -33678,11 +32822,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cMu" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/sorting)
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "cMJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33693,6 +32840,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"cNI" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/engineering/lobby)
 "cOs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33706,8 +32862,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
 "cPy" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "cPL" = (
@@ -33732,8 +32887,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "cSf" = (
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/structure/window/reinforced/spawner/directional/north{
+	pixel_y = 1
+	},
+/mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "cSJ" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -33797,10 +32957,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cZF" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dbI" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer4{
 	dir = 1;
@@ -33842,7 +33001,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "ddJ" = (
-/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "deg" = (
@@ -33854,19 +33013,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"dfm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "dfr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -33889,13 +33035,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dgz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "dhz" = (
@@ -33929,13 +33075,11 @@
 /obj/item/exodrone,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
-"dlS" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/station/medical/virology)
 "dma" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/shaft_miner,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dmP" = (
@@ -33955,22 +33099,11 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"dok" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "doo" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/vending/wallmed/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "doz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34018,30 +33151,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "dqw" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "dqG" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dqY" = (
-/obj/machinery/conveyor{
-	id = "CargoLoad";
-	dir = 10
+/obj/machinery/computer/quantum_console{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "dsa" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -34054,14 +33180,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "dsH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/cmo,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/sign/poster/official/no_erp/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "dtM" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -34099,6 +33223,14 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dwI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dxc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -34107,15 +33239,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "dxo" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/camera/directional/north{
-	c_tag = "Ordnance Launch Area";
-	network = list("ss13","rd")
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/engine,
+/area/station/science/ordnance/burnchamber)
 "dye" = (
 /obj/structure/closet/secure_closet/freezer/meat/open,
 /obj/structure/sign/departments/science/directional/north,
@@ -34140,19 +33270,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"dAF" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Medbay Delivery";
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "dAG" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -34191,6 +33308,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/chapel/monastery)
+"dDW" = (
+/obj/item/stack/medical/gauze,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "dEv" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -34214,6 +33336,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"dHZ" = (
+/obj/structure/chair/comfy/black,
+/obj/item/stack/spacecash/c100,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "dJd" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -34295,8 +33423,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dOd" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Cargo Office";
+	name = "Cargo Office Fax Machine"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -34311,6 +33444,7 @@
 	name = "Medbay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dOs" = (
@@ -34323,38 +33457,34 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "dOM" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	dir = 1;
-	name = "Medbay Monitor";
-	network = list("medbay");
-	pixel_y = -30
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/mob/living/basic/pet/dog/corgi,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "dQq" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "dRU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/keycard_auth/directional/west,
+/obj/machinery/button/door{
+	id = "cmoprivacy";
+	name = "CMO Shutter Control";
+	pixel_x = -26;
+	pixel_y = 9;
+	req_access = list("cmo")
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Chief Medical Office";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/command/heads_quarters/cmo)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -34404,20 +33534,20 @@
 	},
 /area/station/hallway/primary/central)
 "dVv" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/abandoned)
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "dVI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/disposal/incinerator)
 "dVK" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/computer/station_alert,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "dWk" = (
 /obj/item/food/meat/slab/monkey,
 /turf/open/floor/plating,
@@ -34438,6 +33568,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dWR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "dXa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -34452,7 +33586,7 @@
 	name = "Supply Dock Loading Door"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/station/cargo/storage)
 "dZj" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
@@ -34488,7 +33622,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "ebw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/preopen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -34537,13 +33674,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "efJ" = (
-/obj/machinery/brm,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "efU" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -34584,6 +33718,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"ekO" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/disposal/incinerator)
 "ekU" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -34591,9 +33737,13 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "elc" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/plaques/kiddie/perfect_drone{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "elk" = (
 /obj/structure/chair/office,
@@ -34608,11 +33758,18 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "elL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/window/reinforced/spawner/directional/west{
+	layer = 2.9
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "ema" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -34649,22 +33806,24 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"eoI" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/carpet,
 /area/station/maintenance/department/crew_quarters/dorms)
 "epX" = (
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/station/ai_monitored/turret_protected/ai)
 "eqf" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "eqg" = (
 /obj/effect/turf_decal/bot,
@@ -34694,9 +33853,12 @@
 /obj/structure/reagent_dispensers/wall/virusfood/directional/north,
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes{
-	layer = 3.1
+	layer = 3.1;
+	pixel_x = -8
 	},
-/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 11
+	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 2
 	},
@@ -34705,13 +33867,27 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"erW" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "esz" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/command/heads_quarters/cmo)
 "eta" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies"
@@ -34768,17 +33944,22 @@
 /turf/open/floor/iron,
 /area/station/service/chapel/monastery)
 "ewd" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ewV" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"ewZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "ezn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34820,18 +34001,10 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "eBk" = (
-/obj/structure/table/glass,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/effect/decal/remains/human,
+/obj/structure/sign/poster/official/no_erp/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "eBS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -34869,6 +34042,21 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"eEz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"eEJ" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Quartermaster"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "eEN" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -34881,14 +34069,15 @@
 /area/station/commons/dorms)
 "eER" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "eFj" = (
-/obj/structure/table/glass,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/mask/surgical,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "eFu" = (
@@ -34898,23 +34087,21 @@
 /turf/open/floor/iron/checker,
 /area/station/service/chapel/monastery)
 "eGk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance"
 	},
-/obj/effect/mapping_helpers/mail_sorting/supply/qm_office,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "eHy" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/south{
-	c_tag = "Bitrunning Den"
-	},
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/item/circuitboard/machine/thermomachine,
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/cable_coil/five,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "eHI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34930,6 +34117,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"eKg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "eLt" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -34954,10 +34147,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eON" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/costume/judgerobe,
@@ -34980,6 +34174,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"eQD" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "eQR" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -34991,20 +34192,14 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"eRb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "eSL" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "eTw" = (
@@ -35043,16 +34238,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "eUA" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay Security Post"
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay Starboard Hall";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "eUU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -35060,20 +34254,10 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "eVr" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = -9;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/structure/disposalpipe/segment,
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -35091,14 +34275,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"eXo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
-"eYr" = (
-/obj/effect/turf_decal/stripes/corner{
+"eWU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
+"eXo" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
+"eYr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -35107,7 +34297,6 @@
 	c_tag = "Experimentation Lab Central";
 	network = list("ss13","rd")
 	},
-/obj/machinery/light/directional/north,
 /obj/machinery/requests_console{
 	department = "Science";
 	name = "Science Requests Console";
@@ -35125,13 +34314,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "eZj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eZm" = (
+/obj/structure/cable,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "eZA" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
@@ -35147,9 +34340,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"faL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "fby" = (
-/turf/closed/wall,
-/area/station/medical/abandoned)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "fbC" = (
 /obj/machinery/atmospherics/components/trinary/filter/layer4,
 /turf/open/floor/iron/dark,
@@ -35227,11 +34432,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "feS" = (
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "feU" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/holopad,
@@ -35245,22 +34449,18 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "fgs" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Medbay Security Post"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
-"fgv" = (
-/obj/machinery/byteforge,
-/obj/effect/turf_decal/box,
-/obj/item/radio/intercom/directional/south,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/area/station/engineering/atmos/hfr_room)
+"fgv" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo Quartermaster's Office"
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/keycard_auth/directional/east,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "fgT" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 4
@@ -35269,11 +34469,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "fhc" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "fhE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -35285,12 +34483,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fhH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/holopad,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "fhM" = (
 /obj/structure/secure_safe{
 	pixel_x = -22
@@ -35305,12 +34500,20 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"fjs" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+"fjc" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/vending/assist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bluespace_vendor/directional/west,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
+"fjs" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "fkH" = (
@@ -35382,11 +34585,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "frX" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/pale/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/flora/rock/pile/icy,
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = -8
 	},
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/landmark/start/hangover,
+/obj/structure/flora/bush/reed/style_random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fsA" = (
@@ -35398,10 +34609,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ftb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/open/space,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "ftW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35479,11 +34689,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "fzB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/wallmed/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
+/obj/structure/curtain/cloth,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "fAe" = (
@@ -35494,12 +34700,13 @@
 /obj/effect/spawner/random/trash/grime,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fAE" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
+/obj/item/trash/tray,
+/obj/item/trash/energybar,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fBp" = (
@@ -35510,6 +34717,7 @@
 /obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
 	name = "Waste to Space"
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fBt" = (
@@ -35542,15 +34750,19 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "fDz" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/light_construct{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "fER" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -35566,9 +34778,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fFv" = (
@@ -35580,12 +34789,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "fGz" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"fGF" = (
+/obj/machinery/atmospherics/components/unary/bluespace_sender{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fIi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -35654,19 +34867,16 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "fMe" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Incinerator Output Pump"
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
-"fMi" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/chair,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/virology)
 "fMm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -35701,8 +34911,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "fRs" = (
-/turf/closed/wall,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "fSg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35752,23 +34968,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"fWl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/door/window/left/directional/north{
-	name = "Monkey Pen";
-	req_access = list("virology")
-	},
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
-"fWq" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/light/directional/south,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "fWv" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Transit"
@@ -35776,9 +34975,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "fWL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "fXs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -35790,19 +34987,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "fYY" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/camera/directional/north{
-	c_tag = "Ordnance Lab Starboard";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/atmos_canister/air,
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door"
@@ -35824,16 +35013,9 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "gbu" = (
-/obj/machinery/button/door/directional/east{
-	id = "south-atmos-shutters";
-	name = "Project Shutters";
-	req_access = list("atmospherics")
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
+/obj/item/trash/chips,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/area/station/maintenance/department/medical)
 "gcn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35844,7 +35026,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "gcq" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -35869,9 +35050,6 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "gfC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -35895,15 +35073,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "gjt" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
+	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/west,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gjN" = (
@@ -35917,12 +35093,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gkG" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/vehicle/ridden/wheelchair{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/medical3,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/medbay/central)
 "gkQ" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
@@ -35958,20 +35134,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "gld" = (
-/obj/machinery/shower/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Exam Room";
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/exam_room)
 "glf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
+/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "glM" = (
@@ -36036,9 +35219,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gpR" = (
 /obj/structure/window/reinforced/spawner/directional/east{
@@ -36057,17 +35238,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "grE" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay Port Hall";
+	network = list("ss13","medbay")
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/structure/table/glass,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gsP" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/mob/living/basic/pet/dog/corgi,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "gtl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/plating,
@@ -36085,11 +35270,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "gup" = (
-/obj/effect/landmark/navigate_destination{
-	location = "AI Satellite"
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "guS" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -36097,25 +35280,17 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "gvf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "gvi" = (
-/obj/effect/turf_decal/bot,
 /mob/living/basic/sloth/paperwork{
 	name = "Taxes"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -36160,21 +35335,24 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "gyj" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
+"gzG" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/west{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
-"gzG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/security/checkpoint/medical)
 "gzM" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/structure/cable,
@@ -36194,6 +35372,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"gBt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "gBw" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -36235,12 +35421,18 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gFf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/obj/machinery/button/door{
+	id = "surgerya";
+	name = "Privacy Shutters Control";
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/surgery)
 "gFo" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/glass,
@@ -36275,18 +35467,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"gGs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "gGy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -36381,25 +35561,18 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "gOH" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "gOS" = (
 /obj/structure/displaycase/trophy,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "gOV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "gPE" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Labor"
@@ -36412,42 +35585,27 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "gQa" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "gRu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Research Security Post"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/science)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "gRv" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "gRQ" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "gRU" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "gSu" = (
 /obj/structure/chair{
 	dir = 8
@@ -36482,6 +35640,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
+"gVu" = (
+/obj/structure/sign/poster/contraband/tipper_cream_soda/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "gVy" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
@@ -36496,22 +35658,25 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "gVY" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -13
+	},
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Lab";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal/directional/north,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gXg" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "gXh" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -36560,9 +35725,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/library/artgallery)
 "gZO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/landmark/start/bitrunner,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "hae" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -36572,9 +35737,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ham" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36592,13 +35755,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hdk" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/mob/living/basic/pet/dog/corgi/puppy/void{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "heC" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -36665,18 +35825,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "hjy" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/flora/bush/large/style_random,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "hkh" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -36692,6 +35844,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"hmK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "hnt" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -36731,14 +35892,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "hsx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/engineering/main)
 "htK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36786,10 +35942,7 @@
 /area/station/maintenance/department/engine)
 "hvF" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hvR" = (
@@ -36815,20 +35968,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hwj" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/cup/soda_cans/lemon_lime{
-	pixel_y = 7
-	},
-/obj/item/toy/cards/deck,
-/obj/machinery/newscaster/directional/west,
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hwx" = (
@@ -36845,8 +35988,14 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/service/chapel/asteroid/monastery)
+"hxM" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "hyA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hzc" = (
@@ -36952,6 +36101,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"hHv" = (
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "hIQ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
@@ -36978,6 +36130,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
+"hKn" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "hLk" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 8;
@@ -37011,21 +36167,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "hMt" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/fax{
-	fax_name = "Chief Medical Officer's Office";
-	name = "Chief Medical Officer's Fax Machine"
-	},
-/obj/structure/table,
 /turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/area/station/medical/exam_room)
 "hME" = (
 /obj/machinery/biogenerator,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -37072,11 +36219,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "hQh" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/bodybags,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/gun/syringe,
+/obj/machinery/door/window/right/directional/north{
+	name = "Secure Storage";
+	req_access = list("command")
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/medical/storage)
 "hQv" = (
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
@@ -37096,6 +36250,14 @@
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"hRp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "hRH" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -37129,6 +36291,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"hUF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "hUJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37185,11 +36352,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "hZZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -37215,9 +36382,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ick" = (
 /obj/structure/cable,
@@ -37241,10 +36406,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "idj" = (
-/obj/machinery/recharge_station,
-/obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 23
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -37316,24 +36483,14 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "iha" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/sink/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/sign/poster/official/work_for_a_future/directional/south,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "ihj" = (
 /obj/item/clothing/suit/toggle/labcoat/science,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"ihJ" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
 "iil" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -37349,6 +36506,13 @@
 /obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/grass,
 /area/station/security/prison)
+"ijQ" = (
+/obj/machinery/modular_computer/preset/id{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "ijU" = (
 /obj/effect/spawner/random/medical/organs,
 /obj/structure/closet/crate,
@@ -37363,6 +36527,14 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"ilh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
@@ -37379,12 +36551,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"ioj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "ipH" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/stripes/line{
@@ -37402,11 +36568,7 @@
 /area/station/security/prison)
 "iqI" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/camera/directional/south{
-	c_tag = "Aft Primary Hallway Engineering";
-	start_active = 1
-	},
-/obj/item/kirbyplants/organic/plant2,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "iqW" = (
@@ -37459,12 +36621,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "ixN" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "plumbing_shutters";
-	name = "Plumbing Shutters"
-	},
+/obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "iyg" = (
 /obj/structure/sign/warning/electric_shock/directional/east,
@@ -37472,6 +36631,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"iyj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"iyy" = (
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "iyJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -37491,23 +36661,10 @@
 /obj/effect/landmark/navigate_destination/dockescpod,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
-"izF" = (
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/station/maintenance/department/science/xenobiology)
 "izP" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Genetics Lab East"
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "iAr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/brown{
@@ -37525,15 +36682,19 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "iBq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical{
+	name = "Psychology"
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/supply/hidden/layer4{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination{
+	location = "Psychology"
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "iBJ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Telecomms External Fore";
@@ -37569,15 +36730,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "iDV" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
+/obj/machinery/conveyor{
+	id = "CargoLoad";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo Bay"
+	},
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/cargo/storage)
 "iEQ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -37587,11 +36748,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "iFy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/firealarm/directional/west,
+/obj/structure/closet/secure_closet/medical2,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/medical/surgery)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37599,12 +36760,6 @@
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"iGp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/station/service/library)
 "iGt" = (
 /obj/machinery/status_display/supply{
 	pixel_x = 32
@@ -37647,29 +36802,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
-"iJb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/sink/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "iJm" = (
-/obj/machinery/coffeemaker/impressa{
-	pixel_y = 8
-	},
-/obj/structure/table,
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo Foyer"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "iJI" = (
 /obj/structure/table/wood,
 /obj/item/plate,
@@ -37707,20 +36844,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"iLl" = (
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "iLF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37753,11 +36876,10 @@
 /turf/open/floor/iron/checker,
 /area/station/service/chapel/monastery)
 "iOi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "iOj" = (
 /obj/structure/mannequin/skeleton,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -37780,12 +36902,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"iQW" = (
-/obj/machinery/light/small/directional/south,
-/mob/living/carbon/human/species/monkey,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
 "iRs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -37806,21 +36922,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "iTx" = (
-/obj/structure/table,
-/obj/item/storage/medkit/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/machinery/door/window/left/directional/north{
-	name = "First-Aid";
-	red_alert_access = 1;
+	name = "Medbay Delivery";
 	req_access = list("medical")
 	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -37835,13 +36944,10 @@
 /turf/open/space/basic,
 /area/space)
 "iUV" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "iUX" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
@@ -37875,30 +36981,42 @@
 /area/station/service/library/artgallery)
 "jbo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 2;
-	output_dir = 1
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining"
 	},
-/turf/closed/wall,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "jbG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "jcQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
-"jdj" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "BountyCubes";
-	name = "Bounty Cubes"
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/obj/item/stack/sheet/plasteel/fifty{
+	pixel_x = 12
+	},
+/obj/item/pipe_dispenser,
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics Fore"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"jdj" = (
+/obj/machinery/modular_computer/preset/cargochat/cargo{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "jdr" = (
-/obj/structure/girder,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37914,8 +37032,8 @@
 	dir = 4
 	},
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jfK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
@@ -37950,6 +37068,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"jhw" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "jhD" = (
 /obj/structure/sink/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
@@ -37964,6 +37090,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jiO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table,
+/obj/item/storage/box/shipping{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/multitool{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo Office"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "jiV" = (
 /obj/structure/table/wood,
 /obj/item/food/chocolatebar,
@@ -38011,71 +37154,24 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"jnG" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 24;
-	req_access = list("virology")
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-viro";
-	id_tag = "viro-access"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "jpa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock"
-	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access = list("virology")
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-viro";
-	id_tag = "viro-access"
+/obj/machinery/suit_storage_unit/medical,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/storage)
 "jqb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/incident_display/delam/directional/south,
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Engineering Lobby";
+	name = "Engineering Lobby Fax Machine"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"jqA" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38105,36 +37201,35 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "jsj" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
+/obj/machinery/computer/atmos_control{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	name = "Atmos RC";
+	pixel_x = 32
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
+"jsD" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
-"jsD" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/machinery/door/window/left/directional/north{
-	name = "Petting Garden"
-	},
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/area/station/cargo/miningdock)
 "jtf" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "jty" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/storage)
 "juh" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -38155,6 +37250,12 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"jvM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "jwe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -38162,6 +37263,7 @@
 	name = "Containment Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "jwm" = (
@@ -38172,7 +37274,7 @@
 "jwM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -38180,10 +37282,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"jxY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "jze" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
@@ -38205,9 +37317,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jzL" = (
-/obj/structure/tank_holder/extinguisher,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/cargo/sorting)
 "jzX" = (
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
@@ -38239,6 +37353,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"jCz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "jCH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -38287,15 +37405,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "jHZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/table,
+/obj/item/reagent_containers/cup/soda_cans/lemon_lime{
+	pixel_y = 7
 	},
-/turf/closed/wall,
-/area/station/maintenance/department/cargo)
+/obj/item/toy/cards/deck,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "jIr" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/firealarm/directional/east,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/hfr_room)
 "jIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38306,21 +37426,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "jIM" = (
-/obj/machinery/status_display/supply{
-	dir = 4;
-	layer = 4;
-	pixel_x = 33
-	},
-/obj/machinery/conveyor{
-	id = "CargoLoad"
-	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/engineering/atmos)
 "jJn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "jJz" = (
@@ -38337,19 +37454,25 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "jKE" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = 8;
+	pixel_y = 22;
+	req_access = list("virology")
+	},
+/obj/machinery/light_switch{
+	pixel_x = -4;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical{
-	name = "Psychology"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination{
-	location = "Psychology"
-	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/virology)
 "jMt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38363,6 +37486,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"jMC" = (
+/obj/structure/fireaxecabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jMD" = (
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -38378,12 +37505,17 @@
 /obj/machinery/door/poddoor/massdriver_chapel,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
+"jNB" = (
+/obj/structure/transit_tube/horizontal,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "jNK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "jOe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -38397,14 +37529,15 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "jOm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "jOw" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -38488,46 +37621,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"jVS" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/item/pen/red,
-/obj/item/stack/medical/gauze,
-/obj/machinery/light/small/directional/east,
-/obj/item/hand_labeler,
-/obj/item/book/manual/wiki/infections,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "jVZ" = (
 /obj/effect/landmark/navigate_destination{
 	location = "Service Hall"
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"jWG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jWH" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/item/clothing/head/utility/welding{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/light/directional/north,
+/obj/structure/plaque/static_plaque/atmos{
+	pixel_y = 32
 	},
-/obj/item/clothing/head/utility/welding{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/multitool{
-	layer = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jXh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -38601,8 +37711,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "kee" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/rack,
+/obj/item/storage/box/shipping,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "kfM" = (
@@ -38645,55 +37757,32 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"khk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
 "khw" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "khJ" = (
-/obj/machinery/computer/records/security{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/mob/living/basic/pet/dog/corgi/puppy,
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-left"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "kkk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/shaker,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"kkQ" = (
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "klo" = (
 /obj/structure/dresser,
 /obj/structure/mirror{
@@ -38711,10 +37800,6 @@
 /obj/item/clothing/under/rank/civilian/clown/sexy,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
-"kmn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
 "kmM" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -38741,6 +37826,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"knZ" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "kqm" = (
 /obj/machinery/door/window/right/directional/south{
 	name = "Morgue Waste Chute";
@@ -38772,12 +37863,9 @@
 /area/station/service/kitchen)
 "krb" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/mask/surgical,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "krC" = (
@@ -38788,6 +37876,8 @@
 /area/station/maintenance/department/science/xenobiology)
 "krI" = (
 /obj/effect/landmark/start/cargo_technician,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "krU" = (
@@ -38819,10 +37909,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "kvU" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kwd" = (
 /obj/structure/toilet{
 	dir = 8
@@ -38848,12 +37939,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "kye" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "kyv" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
@@ -38866,10 +37956,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kzj" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/machinery/suit_storage_unit/atmos,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -38940,18 +38029,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "kEb" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Security Post - Medbay";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/sign/poster/official/love_ian/directional/east,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "kEk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -38992,6 +38074,10 @@
 "kGb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "kGl" = (
@@ -39068,6 +38154,13 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"kLA" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kMO" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -39110,22 +38203,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kPi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light/small/directional/north,
+/obj/structure/noticeboard/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
+"kQy" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"kQy" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/exam_room,
-/turf/open/floor/plating,
-/area/station/medical/exam_room)
 "kQZ" = (
 /obj/structure/closet,
 /obj/item/stack/spacecash/c10,
@@ -39144,6 +38231,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"kRs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/cafeteria,
+/area/station/engineering/lobby)
 "kRK" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -39187,21 +38281,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kTU" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/science/ordnance)
 "kUU" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "kVM" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/mob/living/carbon/human/species/monkey,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "kVN" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/machinery/door/firedoor,
@@ -39221,13 +38314,24 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
-"kWo" = (
-/obj/structure/rack,
-/obj/item/clothing/under/misc/mailman,
-/obj/item/clothing/head/costume/mailman,
-/obj/machinery/light/directional/south,
+"kVS" = (
+/obj/machinery/requests_console/directional/east,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/station/cargo/miningdock)
+"kWc" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"kWo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat AI Chamber South";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "kWQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -39254,23 +38358,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kYt" = (
-/mob/living/basic/butterfly,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "kZU" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lba" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/structure/chair/comfy/black,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "lbC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -39285,8 +38387,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"lcO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "lcU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -39348,13 +38455,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
-"lfI" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
-/area/station/science/genetics)
 "lhi" = (
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -39419,24 +38519,15 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lkK" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/cup/beaker,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
 "lla" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "llS" = (
-/obj/structure/water_source/puddle,
-/obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/item/cigbutt/cigarbutt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lmd" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -39474,10 +38565,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "lqC" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/light/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "lqE" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/spawner/random/maintenance/closet,
@@ -39492,10 +38583,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "lsq" = (
-/obj/structure/mop_bucket,
-/obj/item/mop,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "lsr" = (
 /obj/structure/water_source/puddle,
 /obj/machinery/light/small/directional/east,
@@ -39527,6 +38620,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
+"luW" = (
+/obj/item/pen/red{
+	pixel_y = 7
+	},
+/obj/item/dest_tagger{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/stamp{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/stamp/denied{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "lvB" = (
 /obj/machinery/fax{
 	fax_name = "Detective's Office";
@@ -39551,15 +38664,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "lya" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A"
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "lzJ" = (
 /obj/structure/sign/poster/official/bless_this_spess/directional/south,
 /turf/open/floor/iron/dark,
@@ -39583,12 +38700,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lAR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "lBJ" = (
@@ -39611,11 +38726,6 @@
 /obj/effect/spawner/random/entertainment/cigar,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"lDw" = (
-/obj/structure/flora/grass/jungle,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
 "lEn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
@@ -39630,11 +38740,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "lFi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "lGj" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/iron/cafeteria,
@@ -39666,19 +38778,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"lGX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "lHX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "lIy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat AI Chamber North";
+	network = list("minisat")
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/light/directional/south,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = -24
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "lJr" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -39713,20 +38835,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "lOK" = (
-/obj/structure/closet/crate/medical,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/storage/box/syringes,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "lQn" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -39753,22 +38864,18 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "lSo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "lSp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "lTB" = (
-/obj/machinery/bouldertech/refinery,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "lTC" = (
@@ -39793,8 +38900,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen)
 "lWy" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "lWH" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -39833,15 +38941,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"mau" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "maH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -39888,8 +38990,20 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mdP" = (
-/turf/closed/wall,
-/area/station/science/ordnance/burnchamber)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"mey" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/central)
 "meF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
@@ -39952,13 +39066,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mmV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/science/explab)
 "mnw" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -39970,12 +39082,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "mnE" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/structure/sign/departments/chemistry/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/science/explab)
 "mnG" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
@@ -40009,17 +39120,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
-"mqg" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery)
 "mql" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mqH" = (
@@ -40041,10 +39146,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "mri" = (
-/obj/machinery/byteforge,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "msw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -40114,13 +39218,24 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "mxV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = -32
 	},
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/computer/pandemic,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"myc" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "myk" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -40161,25 +39276,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"mza" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mzl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "mzp" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/latex,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/filingcabinet/filingcabinet,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "mAi" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -40206,6 +39318,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
+"mDq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "mDK" = (
 /obj/structure/table,
 /obj/item/food/squeaking_stir_fry,
@@ -40261,14 +39378,30 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "mIW" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 7;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/item/storage/belt/utility{
+	pixel_y = 16
+	},
+/obj/item/t_scanner{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = -1
+	},
+/obj/item/t_scanner,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_y = -3;
+	pixel_x = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/hfr_room)
 "mJe" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -40303,11 +39436,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"mMd" = (
-/obj/structure/flora/bush/large/style_random,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
 "mNv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/grime,
@@ -40319,14 +39447,9 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "mOx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mOH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -40432,7 +39555,11 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "mYW" = (
-/obj/structure/chair/stool/directional/west,
+/obj/structure/table,
+/obj/item/mod/module/plasma_stabilizer{
+	pixel_y = 7
+	},
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "naq" = (
@@ -40445,10 +39572,13 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "nbt" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "nbP" = (
 /obj/machinery/skill_station,
 /turf/open/floor/iron/dark,
@@ -40470,14 +39600,12 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "ndt" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/cargo/miningdock)
 "ndI" = (
 /obj/item/reagent_containers/cup/glass/bottle/vodka,
 /obj/effect/mapping_helpers/broken_floor,
@@ -40492,26 +39620,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "ndU" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/door/window/left/directional/east{
-	name = "Cargo Desk";
-	req_access = list("shipping")
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
 	},
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
-"nev" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "new" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -40580,6 +39697,13 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"nin" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "niy" = (
 /obj/structure/table,
 /obj/item/food/cookie,
@@ -40617,12 +39741,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "nls" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/closet/crate/preopen,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "nmp" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -40661,10 +39787,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "noM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/machinery/igniter/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "noT" = (
 /obj/structure/reagent_dispensers/plumbed,
 /obj/effect/decal/cleanable/cobweb,
@@ -40710,37 +39835,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"nsD" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	layer = 3.1
-	},
-/obj/effect/turf_decal/tile/blue{
+"ntO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/stamp/head/cmo{
-	pixel_y = 8
-	},
-/obj/item/folder/blue{
-	pixel_x = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
-"ntO" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nvG" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Art Gallery"
@@ -40751,10 +39851,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"nwc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "nwg" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
+"nwu" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/transit_tube,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "nwW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40828,12 +39939,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "nCe" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/surgery)
 "nDo" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
@@ -40886,20 +39994,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"nIr" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/science)
 "nIU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -40911,12 +40005,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nJi" = (
-/obj/machinery/conveyor/inverted{
-	dir = 9;
-	id = "CargoLoad"
+/obj/machinery/conveyor{
+	id = "CargoLoad";
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nJm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -40930,13 +40024,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"nJI" = (
-/obj/machinery/chem_heater,
-/obj/structure/sign/plaques/kiddie/perfect_drone{
-	pixel_y = 32
-	},
-/turf/open/floor/engine,
-/area/station/science/explab)
 "nKQ" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/door/window/right/directional/south{
@@ -40946,12 +40033,28 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"nKT" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "nLa" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"nMF" = (
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Quartermaster's Office";
+	name = "Quartermaster's Fax Machine"
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "nMG" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -41004,6 +40107,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"nOE" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "nOY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41014,10 +40123,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "nPg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "nPh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41036,10 +40148,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
 "nPm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/department/engine)
 "nPn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -41093,6 +40209,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Drone Bay"
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "nTv" = (
@@ -41110,13 +40227,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "nTU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/structure/sign/warning/secure_area,
+/turf/closed/wall,
+/area/station/maintenance/fore)
 "nTV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41138,14 +40251,26 @@
 /turf/open/floor/iron/white,
 /area/station/security/execution/education)
 "nUq" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4
+/obj/structure/table,
+/obj/item/book/manual/wiki/atmospherics{
+	pixel_x = 5;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/item/clothing/head/utility/welding{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/welding{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/multitool{
+	layer = 4;
+	pixel_y = -2;
+	pixel_x = 3
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/hfr_room)
 "nUL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41195,17 +40320,17 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "nWF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "nWO" = (
-/obj/machinery/netpod,
-/obj/structure/sign/poster/contraband/pwr_game/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "nWP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -41235,11 +40360,19 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nYu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "surgerya";
+	name = "Privacy Shutter"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/surgery)
+"nYZ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/ai_monitored/turret_protected/ai)
 "nZp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -41270,17 +40403,17 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "obj" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 24
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/north,
-/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "odc" = (
@@ -41304,16 +40437,11 @@
 /turf/open/floor/grass,
 /area/station/security/prison)
 "ofN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/closet/firecloset{
-	name = "fire extinguishers"
-	},
-/obj/item/extinguisher,
-/obj/item/extinguisher,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ogz" = (
@@ -41341,21 +40469,19 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ohe" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Ordnance Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"oje" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/item/circuitboard/machine/thermomachine,
-/obj/item/stack/sheet/iron/five,
-/obj/item/stack/sheet/iron/five,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
 "okT" = (
 /obj/structure/closet,
 /obj/item/canvas/twentythree_nineteen,
@@ -41381,6 +40507,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"omn" = (
+/obj/structure/chair/comfy/black,
+/obj/item/cigbutt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "omu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -41397,17 +40529,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "omU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
-"onj" = (
-/obj/machinery/piratepad/civilian,
-/obj/effect/turf_decal/stripes/white/end{
-	dir = 4
+/obj/machinery/camera/directional/south{
+	c_tag = "MiniSat Maintenance Port Fore";
+	network = list("minisat")
 	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
+"onj" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -41424,6 +40556,7 @@
 "ooh" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "oon" = (
@@ -41432,9 +40565,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"oov" = (
-/turf/open/floor/engine,
-/area/station/science/circuits)
 "ooU" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -41463,6 +40593,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"oqI" = (
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat AI Chamber East";
+	network = list("minisat")
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "oqY" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -41472,9 +40613,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "orc" = (
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ory" = (
 /obj/machinery/light/directional/east,
@@ -41482,7 +40621,10 @@
 /obj/item/stack/sheet/glass/fifty{
 	layer = 4
 	},
-/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_y = 6;
+	pixel_x = -3
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -41552,12 +40694,14 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "osv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/light_switch/directional/east{
+	pixel_y = 6
 	},
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/firealarm/directional/east{
+	pixel_y = -4
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "ots" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -41573,12 +40717,14 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "otI" = (
+/obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/aisat/exterior)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "otM" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/wood,
@@ -41609,6 +40755,11 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"ouY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "ovM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals Port Fore"
@@ -41659,13 +40810,27 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "ozc" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 10
 	},
-/mob/living/carbon/human/species/monkey,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
+"oAc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/west{
+	c_tag = "Aft Primary Hallway Atmospherics";
+	start_active = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/lizard/wags_his_tail,
@@ -41683,13 +40848,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "oBP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/modular_computer/preset/id{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/area/station/command/heads_quarters/cmo)
 "oCn" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -41709,13 +40879,26 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "oDF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/item/hfr_box/body/fuel_input{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/hfr_box/body/interface{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/hfr_box/body/moderator_input{
+	pixel_y = 3
+	},
+/obj/item/hfr_box/body/waste_output,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "oDP" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Experimentation Lab East";
@@ -41778,17 +40961,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"oFj" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "oFo" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/sign/warning/vacuum/external/directional/north,
@@ -41803,9 +40975,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "oGc" = (
-/mob/living/basic/goat/pete{
-	name = "Pete"
-	},
+/mob/living/basic/goat/pete,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -41826,18 +40996,12 @@
 /turf/open/floor/iron/checker,
 /area/station/service/chapel/monastery)
 "oKI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/area/station/medical/surgery)
 "oLh" = (
 /obj/structure/rack,
 /obj/item/fuel_pellet,
@@ -41848,6 +41012,15 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"oLw" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "oLR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -41858,7 +41031,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "oMx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/button/door{
 	id = "QMLoaddoor2";
 	layer = 4;
@@ -41878,12 +41050,21 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oMH" = (
-/obj/machinery/conveyor{
-	id = "CargoLoad"
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 1;
+	pixel_y = 9
 	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -10;
+	pixel_y = 1
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "oMN" = (
 /turf/open/floor/iron/stairs/left,
 /area/station/maintenance/department/crew_quarters/dorms)
@@ -41902,15 +41083,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "oOm" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "oOS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/rubble,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "oPy" = (
@@ -41918,9 +41099,7 @@
 	name = "Mining Dock Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "oPI" = (
@@ -41950,12 +41129,11 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "oSa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/warning/vacuum/external/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "oSc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -41977,13 +41155,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "oTl" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 28
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/mail_sorting/science/genetics,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "oTp" = (
@@ -42130,27 +41306,28 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "pdW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/atmos_canister/air,
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
 "peY" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pfe" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/machinery/coffeemaker/impressa{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "pfP" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes{
@@ -42177,32 +41354,31 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "phx" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "CMOCell";
-	name = "Personal Examination Room"
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/airlock_controller/incinerator_ordmix{
+	pixel_x = 27
+	},
+/turf/open/floor/engine,
+/area/station/science/ordnance/burnchamber)
 "phJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"piR" = (
-/obj/structure/flora/bush/jungle/a/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/basic/pet/dog/corgi/puppy,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
 "pjO" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"pki" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/atmos_canister/air,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "pkk" = (
 /obj/structure/chair,
 /obj/machinery/light/small/directional/west,
@@ -42281,10 +41457,13 @@
 /turf/closed/wall,
 /area/station/engineering/lobby)
 "ppx" = (
-/obj/effect/decal/remains/human,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/obj/item/toy/plush/moth,
+/obj/structure/sign/poster/official/corporate_perks_vacation/directional/east,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "ppQ" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -42292,22 +41471,15 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
-"ppW" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "pqe" = (
 /turf/open/space/basic,
 /area/space/nearstation)
 "prD" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/surgery)
 "prT" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -42315,6 +41487,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"prV" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "psp" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/cafeteria,
@@ -42326,15 +41506,19 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ptK" = (
-/obj/item/controller{
-	pixel_x = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/compact_remote{
-	pixel_x = -3
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
+"ptV" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "pvK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -42361,16 +41545,18 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pxp" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "pyl" = (
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "pyQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/west,
@@ -42422,17 +41608,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "pBm" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/fifty{
-	pixel_x = 5
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "atmos_project"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -42452,9 +41630,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pDZ" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/machinery/research/anomaly_refinery,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "pEv" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -42474,19 +41653,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "pFM" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "pFS" = (
-/obj/machinery/computer/atmos_control/ordnancemix{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/burnchamber)
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "pGe" = (
 /obj/structure/chair{
 	dir = 1
@@ -42495,25 +41672,25 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pGi" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/west{
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/mob/living/basic/pet/dog/corgi/puppy,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "pGj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"pGM" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat AI Chamber Center";
+	network = list("minisat")
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pHo" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -42532,32 +41709,27 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "pHN" = (
-/obj/structure/chair/sofa/middle{
-	dir = 8
+/obj/structure/closet/crate/medical,
+/obj/item/hemostat,
+/obj/item/scalpel{
+	pixel_y = 12
 	},
+/obj/item/cautery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "pIa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pIh" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Ordnance Storage"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "pIy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -42593,15 +41765,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "pLq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pLv" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 4
@@ -42628,14 +41797,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "pNf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/vending/games,
+/obj/structure/sign/picture_frame/portrait{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "pNi" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/firealarm/directional/south,
@@ -42646,14 +41813,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "pOc" = (
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_y = 4
-	},
-/obj/item/pen/red,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/medical/medbay/central)
 "pOp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -42670,11 +41834,10 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "pOt" = (
-/obj/structure/flora/bush/large/style_random,
-/obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "pPN" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
@@ -42700,20 +41863,13 @@
 /turf/open/floor/iron/checker,
 /area/station/service/chapel/monastery)
 "pTy" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
-"pTD" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/structure/sink/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "pVp" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -42723,9 +41879,10 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "pVr" = (
-/obj/effect/spawner/random/maintenance/closet,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "pVD" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
@@ -42759,15 +41916,20 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pXg" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/closet/firecloset{
+	name = "fire extinguishers"
+	},
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "pXH" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = 32
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -42887,18 +42049,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qhW" = (
-/obj/item/radio/intercom{
-	frequency = 1485;
-	pixel_x = -30
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/east{
+	name = "Atmospherics Desk";
+	req_access = list("atmospherics")
 	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay Psychology Office";
-	network = list("ss13","medbay")
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Security Door"
 	},
-/obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/turf/open/floor/iron/dark,
+/area/station/engineering/lobby)
 "qjx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -42946,13 +42107,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qnJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/departments/psychology/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay Entrance";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qnT" = (
@@ -42960,20 +42119,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "qof" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = -34
-	},
 /obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Quartermaster's Office";
-	name = "Quartermaster's Fax Machine"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/item/stack/sheet/cardboard,
+/obj/item/airlock_painter/decal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "qoh" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -42985,15 +42137,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "qpv" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/photocopier,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "qpI" = (
@@ -43001,6 +42148,12 @@
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"qpR" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "qpT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -43013,26 +42166,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"qqQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"qqX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/bed/dogbed/runtime,
-/mob/living/basic/pet/cat/runtime,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "qrw" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/delivery_chute{
@@ -43054,20 +42187,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"qtf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination{
-	location = "Xenobiology"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "qtA" = (
-/obj/machinery/air_sensor/ordnance_burn_chamber,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
 "qtD" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -43084,7 +42209,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qux" = (
@@ -43094,47 +42219,44 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "qvx" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen{
+	layer = 3.1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qvH" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qvM" = (
-/obj/machinery/computer/piratepad_control/civilian{
-	dir = 8;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/stripes/white/end{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "qww" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "qwJ" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/structure/table/glass,
+/obj/item/surgery_tray/full,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/apron/surgical,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay Surgery A";
-	network = list("ss13","medbay")
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"qwP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "qxq" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/cable,
@@ -43142,9 +42264,12 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "qxs" = (
-/obj/item/ai_module/toy_ai,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "qxG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -43154,20 +42279,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "qxU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "qyW" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "qzm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
 /area/station/engineering/lobby)
 "qAS" = (
 /obj/machinery/light/small/directional/east,
@@ -43192,32 +42321,32 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "qEf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"qEm" = (
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "BountyCubes"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/sorting)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
+"qEm" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "qEx" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qEN" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/reed/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/hallway/primary/central)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "qFu" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -43242,8 +42371,13 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "qHa" = (
-/turf/closed/wall/r_wall,
-/area/station/security/checkpoint/medical)
+/obj/machinery/door/window/left/directional/south{
+	name = "Therapy Pen"
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/psychology)
 "qHf" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -43273,19 +42407,23 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "qIl" = (
-/obj/effect/turf_decal/tile/green{
+/obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "qIn" = (
-/obj/machinery/atmospherics/components/unary/bluespace_sender{
-	dir = 4
+/obj/machinery/button/door/directional/north{
+	id = "atmos_project";
+	name = "Project Shutters";
+	req_access = list("atmospherics")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Atmospherics Central"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qIv" = (
 /obj/structure/table,
@@ -43305,13 +42443,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qIH" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/conveyor{
-	id = "CargoLoad"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/machinery/computer/order_console/bitrunning,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "qIO" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -43345,19 +42480,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
-"qMi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/geneticist,
-/obj/structure/chair/office,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "qOx" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
@@ -43395,6 +42517,19 @@
 /obj/effect/mapping_helpers/mail_sorting/service/dormitories,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"qQE" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"qSy" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "qUe" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
@@ -43468,15 +42603,11 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "qXb" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining"
+/obj/machinery/computer/security/qm{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "qXj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43510,35 +42641,43 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"rah" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/station/maintenance/department/science/xenobiology)
-"rax" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
-"rbg" = (
-/obj/machinery/door/poddoor/massdriver_ordnance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/line{
+"qZC" = (
+/obj/structure/closet/masks,
+/obj/item/food/deadmouse,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
+"qZN" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"rah" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
-/area/station/science/ordnance)
+/area/station/maintenance/department/science/xenobiology)
+"rax" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
+"rbg" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "rbo" = (
 /obj/effect/spawner/atmos_canister/anesthetic_mix,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -43577,16 +42716,11 @@
 /turf/open/floor/plating,
 /area/station/security/prison)
 "rfm" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/disposal/incinerator)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rgg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -43652,14 +42786,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"rjw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "rjF" = (
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "rlj" = (
-/obj/structure/flora/bush/large/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "rlp" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron/dark,
@@ -43711,8 +42856,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -43803,6 +42949,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"rtE" = (
+/obj/machinery/computer/department_orders/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rtG" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -43835,37 +42987,42 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/station/service/chapel/asteroid/monastery)
+"ruk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "rur" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"rus" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology Airlock";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "rvH" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "south-atmos-shutters"
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/ordnance,
+/obj/item/analyzer,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 16
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/item/pipe_dispenser,
+/obj/item/holosign_creator/atmos{
+	pixel_x = 5;
+	pixel_y = 9
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "rvO" = (
-/obj/effect/spawner/random/maintenance/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/camera/directional/east{
+	c_tag = "Ordnance Storage";
+	network = list("ss13","rd")
+	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
 "rxa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -43883,11 +43040,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rxV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+/obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/burnchamber)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "ryy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -43922,41 +43081,54 @@
 /area/station/service/library/artgallery)
 "rAP" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rBg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rBu" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat External Port";
+	network = list("minisat")
+	},
+/turf/open/space,
+/area/space/nearstation)
 "rCe" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/burnchamber)
-"rCo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
+"rCo" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	layer = 3.1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/stamp/head/cmo{
+	pixel_y = 8
+	},
+/obj/item/folder/blue{
+	pixel_x = 15
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/command/heads_quarters/cmo)
 "rCr" = (
 /obj/machinery/computer/exoscanner_control{
 	dir = 1
@@ -43978,11 +43150,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rEd" = (
-/obj/structure/rack,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/item/integrated_circuit/loaded/hello_world,
-/turf/open/floor/engine,
-/area/station/science/circuits)
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "rEf" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark,
@@ -43994,12 +43164,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rFq" = (
-/obj/machinery/suit_storage_unit/medical,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/virology)
 "rHe" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -44016,9 +43186,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rHh" = (
-/obj/structure/flora/bush/ferny/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/machinery/turretid{
+	control_area = "/area/station/ai_monitored/turret_protected/ai";
+	name = "AI Chamber turret control";
+	pixel_x = 5;
+	pixel_y = -24
+	},
+/obj/machinery/holopad/secure,
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom";
+	pixel_y = -40
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "rHj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/botanist,
@@ -44029,9 +43212,9 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "rHG" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "rJg" = (
@@ -44074,14 +43257,20 @@
 /turf/open/floor/iron/white,
 /area/station/security/execution/education)
 "rKL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/chair,
+/obj/effect/spawner/random/food_or_drink/donkpockets_single,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
+"rKN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2
 	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "rLi" = (
 /obj/machinery/button/door{
 	id = "shootshut";
@@ -44106,18 +43295,20 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "rMV" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/entertainment/drugs,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "rMZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "rNB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "rNJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44127,12 +43318,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"rOT" = (
+/obj/machinery/shower/directional/west,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/restrooms)
 "rPW" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	pixel_y = 32
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "QM #2"
 	},
-/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rQa" = (
@@ -44161,6 +43358,13 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"rSU" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/mob/living/basic/chicken{
+	name = "Bloodthirsty Peckins"
+	},
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical)
 "rTD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -44168,12 +43372,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rWv" = (
-/obj/machinery/door/window/right/directional/south{
-	name = "Bounty Cubes";
-	req_access = list("shipping")
-	},
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/restrooms)
 "rWE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -44198,9 +43400,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "rXT" = (
-/obj/structure/sign/poster/official/ian,
-/turf/closed/wall,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "rYC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -44240,16 +43443,13 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"sci" = (
-/obj/item/toy/plush/plasmamanplushie,
-/turf/open/floor/plating,
-/area/station/science/ordnance/burnchamber)
 "scj" = (
 /obj/structure/table,
 /obj/item/radio/intercom/prison/directional/north,
@@ -44274,9 +43474,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "sea" = (
-/obj/structure/flora/bush/large/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sep" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/toy/figure/curator,
@@ -44312,13 +43516,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "skj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "skw" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/plaques/kiddie{
@@ -44359,16 +43560,12 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "snm" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
-"snT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery)
+/area/station/medical/medbay/central)
 "snY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -44383,6 +43580,7 @@
 	name = "Psychology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "spo" = (
@@ -44392,14 +43590,18 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "spz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/table,
+/obj/item/electropack{
+	pixel_y = 6;
+	pixel_x = 10
 	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 1
+/obj/item/taperecorder{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/item/screwdriver,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "sqh" = (
 /obj/structure/chair{
 	dir = 8
@@ -44418,20 +43620,17 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sql" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sqZ" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Supermatter Mix Pump"
+/obj/machinery/porta_turret/ai{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "sri" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Theatre Maintenance"
@@ -44443,6 +43642,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/theater)
+"ssc" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "ssx" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -44526,15 +43734,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"szK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "sAD" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sAK" = (
@@ -44542,8 +43757,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "sBf" = (
-/turf/closed/wall,
-/area/station/cargo/office)
+/obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "sBA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -44593,13 +43811,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"sHH" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
 "sIq" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -44620,6 +43831,12 @@
 "sJr" = (
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"sJJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sKa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -44634,11 +43851,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"sKo" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Bridge Starboard Fore";
+	network = list("minisat")
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "sLv" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -44646,28 +43870,32 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "sLD" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/item/trash/popcorn,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
+"sLU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/depsec/science,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/science)
+/turf/open/space,
+/area/space/nearstation)
 "sNz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "sOB" = (
-/turf/closed/wall,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -44686,29 +43914,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"sPZ" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "sQt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/button/door{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 24;
-	pixel_y = 23;
-	req_access = list("cargo")
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sSl" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/medbay/central)
 "sSs" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -44716,21 +43943,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "sUP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "sWj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sWM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/curtain/cloth,
 /turf/open/floor/iron/white,
-/area/station/science/ordnance)
+/area/station/medical/surgery)
 "sWU" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -44795,25 +44025,17 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"tak" = (
+"tal" = (
 /obj/machinery/shower/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"tal" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/defibrillator_mount/directional/south,
-/obj/machinery/stasis,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "tan" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/light_switch/directional/north,
@@ -44846,15 +44068,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"tbS" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/east,
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
 "tcm" = (
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -44874,17 +44087,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "tcX" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/directional/south,
+/obj/machinery/defibrillator_mount/directional/south,
+/turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "tdp" = (
 /obj/structure/rack,
 /obj/item/stack/package_wrap,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/item/hand_labeler,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/directional/east,
@@ -44913,10 +44124,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "teI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/structure/table,
+/obj/item/multitool/circuit{
+	pixel_x = 7
 	},
-/turf/open/floor/iron/dark,
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit{
+	pixel_x = -8
+	},
+/turf/open/floor/engine,
 /area/station/science/explab)
 "tfc" = (
 /obj/effect/landmark/start/assistant,
@@ -44950,68 +44166,45 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"tgL" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/science/ordnance/burnchamber)
 "tgR" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/toy/figure/chaplain,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "thT" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "thW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"tim" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Testing Lab Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "tix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/atmos)
+/area/space/nearstation)
 "tjj" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/window/left/directional/north{
+	name = "Monkey Pen";
+	req_access = list("virology")
+	},
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
+"tkl" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal/directional/north,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
-"tkl" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -45094,18 +44287,22 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "tqe" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Bridge External Access"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "tqC" = (
 /turf/closed/wall,
 /area/station/medical/storage)
 "tqE" = (
-/obj/machinery/bluespace_vendor/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "tqO" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Coroner's Office"
@@ -45179,12 +44376,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "tuM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/space,
+/area/space/nearstation)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -45218,12 +44413,10 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "txB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "txZ" = (
@@ -45244,22 +44437,19 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tzM" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/navigate_destination/med,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "tAK" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/space,
+/area/space)
 "tBb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -45281,15 +44471,19 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
+"tDQ" = (
+/obj/structure/tank_holder/extinguisher,
+/obj/machinery/camera/directional/south{
+	c_tag = "Cargo Break Area"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "tEE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/landmark/start/psychologist,
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "tES" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -45358,18 +44552,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "tJB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/button/door{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 24;
-	pixel_y = -23;
-	req_access = list("cargo")
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/science/ordnance/testlab)
 "tJH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -45430,21 +44617,17 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "tOf" = (
-/obj/structure/flora/bush/pointy/style_random,
-/obj/structure/flora/bush/leavy/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/hallway/primary/central)
-"tOk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
+"tOk" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "tOP" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -45455,11 +44638,19 @@
 	},
 /turf/closed/wall,
 /area/station/engineering/main)
-"tPZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+"tQD" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "tQJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cold Loop Bypass"
@@ -45467,17 +44658,15 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tQP" = (
-/obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_y = 34
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/fax{
-	fax_name = "Cargo Office";
-	name = "Cargo Office Fax Machine"
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -45486,10 +44675,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"tSd" = (
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "tSK" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -45530,7 +44715,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/space,
-/area/station/engineering/atmos)
+/area/space/nearstation)
 "tUr" = (
 /obj/structure/flora/bush/flowers_yw/style_3,
 /turf/open/floor/grass,
@@ -45573,22 +44758,11 @@
 /obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"tWt" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay Treatment";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "tXL" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tXV" = (
@@ -45601,9 +44775,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
 "tYu" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/item/stack/sheet/cardboard,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tYF" = (
@@ -45613,7 +44786,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "tYU" = (
@@ -45645,11 +44817,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"uaP" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/burnchamber)
 "uaR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -45671,10 +44838,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "udR" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/three,
@@ -45716,15 +44886,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "ugy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
+"uhN" = (
+/obj/machinery/byteforge,
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
-"uhN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -45748,23 +44918,6 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/department/engine)
-"uko" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"ulf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "ulq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45802,9 +44955,6 @@
 /area/station/maintenance/department/engine)
 "ume" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab"
 	},
@@ -45814,6 +44964,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "umh" = (
@@ -45821,25 +44975,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "umM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Psychology Office";
+	name = "Psychology Office Fax Machine"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Chief Medical Officer's Desk";
-	name = "Chief Medical Officer RC";
-	pixel_x = 30
-	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "umO" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/cup/rag,
@@ -45856,6 +44999,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"une" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "QM #3"
+	},
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/mulebot,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uno" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45893,31 +45046,24 @@
 /turf/open/floor/iron,
 /area/station/security)
 "uqs" = (
-/obj/structure/flora/bush/jungle/a/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Storage"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "uqJ" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
-"urk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "urG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/hfr_room)
+/obj/machinery/shower/directional/south,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "urO" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/structure/closet/secure_closet/medical1{
-	pixel_x = -3
-	},
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "urP" = (
@@ -45930,9 +45076,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
 "urZ" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "usl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
 /turf/open/floor/iron/dark,
@@ -45983,11 +45129,15 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "uwh" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/item/controller{
+	pixel_x = 5;
+	pixel_y = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/compact_remote{
+	pixel_x = -3
+	},
+/turf/open/floor/engine,
 /area/station/science/explab)
 "uwj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -45997,31 +45147,30 @@
 /turf/open/floor/plating,
 /area/station/medical/morgue)
 "uwF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Office Maintenance"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/shipping,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uyy" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "uyF" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Supermatter Mix Pump"
 	},
-/obj/machinery/atmospherics/components/binary/crystallizer{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uyN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -46033,11 +45182,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "uyZ" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "uzl" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -46067,10 +45215,7 @@
 /turf/open/floor/iron,
 /area/station/security)
 "uzx" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Genetics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uAh" = (
@@ -46078,24 +45223,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "uAs" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
-"uAx" = (
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/landmark/start/geneticist,
-/obj/structure/chair/office{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/medical/medbay/lobby)
+"uAx" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -46140,15 +45277,27 @@
 "uEH" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
+"uEQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/cafeteria,
+/area/station/engineering/lobby)
 "uEY" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "uFc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"uFr" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uHd" = (
@@ -46213,6 +45362,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "uLp" = (
@@ -46236,6 +45386,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "uMr" = (
@@ -46257,11 +45408,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"uOA" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/ferny/style_random,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
 "uPu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -46272,7 +45418,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/space,
-/area/station/engineering/atmos)
+/area/space/nearstation)
 "uPG" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -46352,11 +45498,21 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uVD" = (
-/obj/machinery/computer/quantum_console,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	pixel_y = 32
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/table,
+/obj/item/computer_disk/quartermaster,
+/obj/item/clipboard,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/coin/silver,
+/obj/item/stamp/head/qm,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "uVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46425,46 +45581,40 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "uYT" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair/sofa/right{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "uZJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/machinery/turretid{
+	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
+	name = "AI Satellite turret control";
+	pixel_x = -5;
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "vaa" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"vbv" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/iron/freezer,
-/area/station/medical/virology)
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"vbv" = (
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/hello_world,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "vbR" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -46483,6 +45633,7 @@
 "vdg" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "vek" = (
@@ -46492,12 +45643,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "veM" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "BountyCubes"
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/sorting)
+/obj/effect/spawner/atmos_canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
 "vfw" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
@@ -46516,12 +45666,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "vgg" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/structure/chair/sofa/right,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/machinery/module_duplicator,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "vgp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -46542,7 +45690,7 @@
 	name = "Supply Dock Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/structure/fans/tiny/invisible,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vhb" = (
@@ -46591,33 +45739,37 @@
 /area/station/medical/chemistry)
 "vlV" = (
 /obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/gun/syringe,
-/obj/machinery/door/window/right/directional/north{
-	name = "Secure Storage";
-	req_access = list("command")
+/obj/item/storage/medkit/fire{
+	pixel_x = 3;
+	pixel_y = 3
 	},
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/left/directional/north{
+	name = "First-Aid";
+	red_alert_access = 1;
+	req_access = list("medical")
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay Storage";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vmo" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/table/wood,
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A"
 	},
-/obj/item/pen,
-/obj/item/folder/white{
-	pixel_x = 14;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "vmA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46630,18 +45782,25 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vmB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "vmY" = (
 /obj/machinery/oven,
 /turf/open/floor/iron,
 /area/station/service/chapel/monastery)
+"voy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "voI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46658,27 +45817,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "voX" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "north-atmos-shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
-"vpz" = (
-/obj/structure/girder,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "vrP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "vrX" = (
@@ -46687,26 +45836,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"vsn" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 1;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
 "vsv" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/digital_clock/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/grimy,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "vsw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vsJ" = (
@@ -46759,24 +45899,22 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "vxp" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "vyL" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"vzp" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vzP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46803,21 +45941,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"vCA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/landmark/navigate_destination{
-	location = "Ordnance Launch"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "vCC" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"vCE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery)
 "vFR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -46860,14 +45996,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"vII" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "vIM" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
@@ -46876,17 +46004,6 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"vJR" = (
-/obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = 7
-	},
-/obj/item/multitool/circuit,
-/obj/item/multitool/circuit{
-	pixel_x = -8
-	},
-/turf/open/floor/engine,
-/area/station/science/circuits)
 "vKD" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -46902,11 +46019,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vMx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vNA" = (
@@ -46943,13 +46056,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "vQz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/conveyor{
-	id = "CargoLoad";
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "vQD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47032,6 +46143,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"vUO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vVQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -47045,7 +46161,9 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 12
+	},
 /obj/item/stack/rods/fifty,
 /obj/item/clothing/glasses/welding,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -47078,11 +46196,12 @@
 /area/station/maintenance/department/medical/morgue)
 "vZP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/north{
+/obj/machinery/door/firedoor,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/door/window/right/directional/south{
 	name = "Cargo Desk";
 	req_access = list("shipping")
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "wcs" = (
@@ -47118,6 +46237,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"weU" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "wfc" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -47222,24 +46345,9 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"wkZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/shower/directional/east{
-	name = "emergency shower"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "wlc" = (
-/obj/structure/mineral_door/wood{
-	name = "The Roosterdome"
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wlX" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
@@ -47303,18 +46411,8 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "wtj" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -47336,17 +46434,29 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"wvM" = (
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat AI Chamber West";
+	network = list("minisat")
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "wwp" = (
-/obj/item/kirbyplants/organic/plant21,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/lattice,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wwG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47447,18 +46557,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"wBU" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay Port Hall";
-	network = list("ss13","medbay")
-	},
-/obj/structure/chair,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "wCj" = (
 /obj/item/paint/paint_remover{
 	pixel_y = 8
@@ -47496,12 +46594,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"wEF" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "wFC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -47517,28 +46609,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wFT" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/folder/white{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/pen{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_x = -1;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "wFW" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice/catwalk,
@@ -47551,11 +46623,13 @@
 /turf/closed/wall,
 /area/station/maintenance/disposal)
 "wGM" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/mob/living/basic/pet/dog/corgi/puppy,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/station/medical/virology)
 "wIv" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -47567,9 +46641,10 @@
 /turf/open/floor/plating,
 /area/station/service/library/artgallery)
 "wJl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/black,
+/obj/item/trash/pistachios,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "wJL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -47594,28 +46669,6 @@
 /obj/item/training_toolbox,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"wLl" = (
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = 8;
-	pixel_y = 22;
-	req_access = list("virology")
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "wLq" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4{
 	dir = 8
@@ -47713,11 +46766,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
-"wQQ" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -47753,16 +46801,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "wTv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/mining{
-	name = "Bitrunning Den"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/cargo/bitrunning/den)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/space,
+/area/space/nearstation)
 "wTz" = (
 /obj/structure/rack,
 /obj/item/food/mint,
@@ -47809,14 +46851,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wTZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/medbay/central)
 "wUf" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -47888,13 +46929,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "xae" = (
-/obj/machinery/bouldertech/refinery/smelter,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Security Door"
 	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/office)
 "xah" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47933,12 +46978,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xbj" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "xbu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47947,6 +46991,14 @@
 "xbJ" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
+"xbT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "xbX" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -47976,16 +47028,14 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xdY" = (
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "xee" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -48000,35 +47050,26 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"xgt" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "xgv" = (
-/obj/machinery/fax{
-	fax_name = "Psychology Office";
-	name = "Psychology Office Fax Machine"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/purple,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "xgG" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "xgP" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "south-atmos-shutters"
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "xhj" = (
 /obj/structure/chair{
 	dir = 8
@@ -48047,20 +47088,20 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "xhT" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/computer/department_orders/medical{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "xja" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "xje" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -48109,6 +47150,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"xlD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/item/ai_module/toy_ai,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "xlQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48139,13 +47187,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xne" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "xnm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -48180,18 +47228,12 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "xpr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"xqq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "xrB" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/dark,
@@ -48202,17 +47244,23 @@
 /area/station/engineering/main)
 "xsO" = (
 /obj/item/ectoplasm,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "xte" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
+"xts" = (
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/science/genetics)
 "xtv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -48287,10 +47335,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"xyI" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "xyK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -48306,12 +47350,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "xzp" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/vacuum/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xzN" = (
@@ -48322,10 +47367,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xAR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xCV" = (
@@ -48359,25 +47404,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"xGi" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
-"xIx" = (
-/obj/machinery/light/small/directional/east,
+"xFG" = (
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
+"xGi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"xIx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "xIP" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -48407,18 +47451,21 @@
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
 "xKm" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "xKD" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -48454,8 +47501,7 @@
 /turf/closed/wall/mineral/iron,
 /area/station/service/chapel)
 "xOt" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xOC" = (
@@ -48466,15 +47512,9 @@
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "xPa" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -6
-	},
-/turf/open/floor/engine,
+/obj/machinery/light/directional/south,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
 /area/station/science/explab)
 "xPY" = (
 /obj/machinery/duct,
@@ -48487,17 +47527,14 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "xQr" = (
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
-/obj/item/reagent_containers/syringe,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/science/xenobiology)
 "xQO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/medical/emergency,
@@ -48607,11 +47644,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xXA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "xXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48630,22 +47668,22 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "xZS" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"yat" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
-"ybu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/plaque,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
+"ybu" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1;
+	pixel_y = 4
+	},
+/obj/structure/sign/poster/official/help_others/directional/south,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet/purple,
+/area/station/medical/psychology)
 "ybJ" = (
 /obj/machinery/igniter/incinerator_atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer4,
@@ -48689,14 +47727,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ydL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "CMO Office"
+/obj/machinery/computer/security{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/cmo)
+/obj/machinery/camera/directional/east{
+	c_tag = "Security Post - Medbay";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	dir = 1;
+	name = "Medbay Monitor";
+	network = list("medbay");
+	pixel_y = -30
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "ydZ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
@@ -48711,6 +47760,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
+"yeF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "yfy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -48722,6 +47776,15 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"ygT" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "ygZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/mess,
@@ -66658,7 +65721,7 @@ abI
 aht
 wWO
 wWO
-iGp
+cyU
 cAV
 ckH
 cAt
@@ -66915,7 +65978,7 @@ aaa
 aht
 aaa
 aaa
-iGp
+cyU
 cqy
 cAC
 cAu
@@ -67172,7 +66235,7 @@ aaa
 aht
 aaa
 aaa
-iGp
+cyU
 tea
 cAD
 cAv
@@ -67429,7 +66492,7 @@ aaa
 aht
 aaa
 aaa
-iGp
+cyU
 vFZ
 ckH
 cAt
@@ -68703,14 +67766,14 @@ aht
 aaa
 aaa
 aht
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
+eZM
+crz
+crz
+eZM
+eZM
+crz
+crz
+eZM
 aht
 aaa
 aaa
@@ -68916,7 +67979,7 @@ oTp
 aiu
 aJF
 aKE
-gvf
+aWE
 kvj
 aOk
 aWE
@@ -68959,30 +68022,30 @@ aaa
 aht
 aaa
 aaa
-aht
 eZM
+eZM
+tqE
 fWL
+cCT
+fWL
+bTS
 fWL
 eZM
 eZM
-eZM
-eON
-eON
-eZM
-eZM
-eZM
-eZM
-eZM
+aaa
+aaa
+aaa
+aaa
 aht
 aaa
-bva
-bIZ
-bIZ
-bva
-bva
-bIZ
-bIZ
-bva
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aht
@@ -69217,30 +68280,30 @@ bSl
 bSl
 bSl
 eZM
-eZM
+weU
 chf
-cry
-cdo
-bNQ
-cwx
-bDf
-bCa
-cgO
+chf
+chf
+chf
+chf
+chf
+beN
 eZM
-lsq
-gXg
-crz
+aaa
+aaa
+aaa
+aaa
 aht
-bva
-bva
-bJa
-bHQ
-bLt
-bHQ
-bNF
-bHQ
-bva
-bva
+aaa
+bHI
+aht
+bHI
+aht
+aht
+aht
+aht
+aht
+bHI
 aht
 aht
 aht
@@ -69474,30 +68537,30 @@ bSi
 bEj
 bFF
 eZM
-cZF
+fWL
 wJl
 bDf
-bCa
 cAi
-eZM
-eZM
-bNQ
-eZM
-eZM
-uyZ
-eZM
-eZM
-bva
-bva
-bHP
-bJb
-bJb
-bJb
-bJb
-bJb
-bJb
-bPp
-bva
+cAi
+pVr
+ckg
+fWL
+crz
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aht
 aaa
@@ -69731,36 +68794,36 @@ bSi
 bEk
 eZM
 eZM
-rMV
-bCa
-eZM
+fWL
+dHZ
+rSU
 cwz
-eZM
-eZM
+aUs
+gup
 ckg
-bCa
-bJj
-cwx
-clm
-bNQ
-bNt
+fWL
+crz
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bva
-bGK
-bHQ
-bJc
-bKh
-bLu
-bLu
-bNG
-bOz
-bHQ
+bva
 bIZ
-aaa
-aht
-aaa
-aht
-aaa
-aaa
+bIZ
+bIZ
 aaa
 bGI
 bNs
@@ -69971,7 +69034,7 @@ aZx
 aZx
 aYG
 aYG
-baK
+bKh
 baK
 bnq
 baM
@@ -69988,36 +69051,36 @@ bDh
 bEl
 eZM
 crB
-nPm
-uPG
-uMY
-uyy
-uPG
-pZT
-xKD
-pZT
-pZT
-bHT
-pZT
-uPG
-uPG
-bva
-bGL
-bHQ
-bJd
-bKi
-bLv
-bMA
-bNH
-bOz
-bHQ
+fWL
+lba
+cxM
+cwz
+auL
+bFL
+ckg
+fWL
+crz
+aaa
+aaa
+aaa
+aht
+uIv
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bIZ
-aaa
-aht
-aaa
-aht
-aaa
-aaa
+caZ
+cbS
+ccN
+bIZ
 aaa
 bGI
 bNs
@@ -70244,36 +69307,36 @@ bSl
 eZM
 bEm
 eZM
-uyy
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-eZM
-csh
-bva
+qZC
+bnc
+omn
+aSf
+bPR
+bPR
+ans
+ckg
+fWL
+crz
+aht
+aht
+aht
+aht
+czV
 bGM
-bHQ
-bJe
+bGM
 bKj
-bLv
-bMB
-bNI
-bOz
-bHQ
-bIZ
-aaa
+bKj
 bva
 bva
+bva
+bva
+aht
+aht
+aht
 bIZ
-bIZ
+cba
+cbT
+bDi
 bIZ
 aht
 aYE
@@ -70500,38 +69563,38 @@ bAL
 bSl
 eUe
 csB
-bCa
+eZM
 uyy
-bSl
-aRJ
-doo
-nCe
-ckz
-bKn
-bLz
-bMF
-bNL
-bOD
-aht
-bIZ
-ary
+fWL
+sLD
+dDW
+chf
+bJc
+chf
+chf
+gbu
+eZM
+aaa
+aaa
 bva
 bva
+czV
+tkl
 bHR
 bJf
 bKk
-bLx
+bva
 bLx
 bNJ
-bOz
-bHQ
 bIZ
 aaa
-bIZ
-caZ
-cbS
-ccN
-bIZ
+aaa
+aaa
+bva
+cbb
+bDi
+ccO
+bva
 aaa
 bGI
 bNs
@@ -70757,38 +69820,38 @@ bSl
 bSl
 cdB
 csB
-vOw
-uPG
-bSl
-erQ
-oat
-iMd
-sEN
-bKo
-bLA
-bMG
-bNM
-bOD
-aht
-bIZ
-bmf
-bXU
+eZM
+eZM
+pyl
+aaO
+fDz
+fWL
+eoI
+fDz
+urZ
+pxp
+eZM
+eZM
+eZM
 bva
+qQE
+cvI
+jdr
 bHQ
 bJg
 bKl
-bJb
-bMC
-bJb
-bJb
-bPq
 bva
-uIv
-bIZ
-cba
-cbT
-bDi
-bIZ
+bNK
+bva
+bva
+aaa
+aaa
+aaa
+bva
+bva
+bNK
+bva
+bva
 aaa
 bGI
 bIZ
@@ -71015,37 +70078,37 @@ bBY
 tNl
 btQ
 ajJ
-cuY
-bSl
-ciJ
-qIl
-iMd
-bJm
-bKn
-bKn
-bKn
-bKn
-bEr
-aht
-bva
+eZM
+eZM
+eZM
+eZM
+cqH
+cqH
+eZM
+eZM
+eZM
+eZM
+bMd
+avP
+qEx
 pFM
 apS
-bva
-bmd
-bJh
-bKm
-bHQ
-bMD
-bKm
-bOA
-bPr
-bva
-czV
-bva
-cbb
+bVu
+bWZ
 bDi
-ccO
+bDi
+bDi
+bWZ
+bDi
 bva
+bva
+aaa
+aaa
+aaa
+bIZ
+dXa
+bIZ
+aaa
 aaa
 aaa
 ctS
@@ -71270,37 +70333,37 @@ bzD
 bAM
 bvb
 bDj
-bSl
-bSl
-bSl
-bSl
-bEr
-kTU
-sEN
-sEN
-lya
-bLA
-bMG
-pOc
-bOD
-aht
-bIZ
-bmf
-ccN
+bJj
+uPG
+eZM
+bNQ
+aaK
+eZM
+bRu
+bTP
+eZM
+aaK
+bCa
+bRu
+bCa
+bJj
 bva
+pki
+aec
+bva
+bIX
 bva
 bva
 bva
 wlc
-wlc
+dXa
+aNT
 bva
 bva
 bva
 bva
-cuX
 bva
-bva
-bNK
+ckm
 bva
 bva
 bva
@@ -71527,37 +70590,37 @@ eZM
 eZM
 eZM
 uMY
-bSl
-uko
-sSl
-bHS
-bEr
-wLl
-iMd
-bGW
-bKn
-cxM
-cAS
-lkK
-bOD
-aht
-bIZ
+bCa
+uPG
+pZT
+uPG
+uPG
+pZT
+pZT
+pZT
+pZT
+pZT
+uPG
+uPG
+pZT
+uPG
+ahp
 mTp
-bTl
-qEx
-dXa
-wwp
+bKV
 bva
-bsn
-bME
 bva
+bva
+csh
+nQb
+bZt
+bDi
 sKe
-hZZ
-vGg
-nPg
+bXa
+bRD
+bRD
 bXa
 bZr
-bXa
+bRD
 bXa
 bXa
 ccJ
@@ -71784,33 +70847,33 @@ juh
 bAN
 eZM
 dcN
+bCa
+bJj
+bCa
+bCa
 bSl
-gld
-ybu
-tuM
-jpa
-gGs
-aNO
-cBK
-bKn
-bKn
-bEr
-bEr
-bEr
-aht
+bSl
+bSl
+bSl
+bSl
+bSl
+bSl
+bSl
+bSl
+eZM
 bva
-bmf
-nQb
+bbO
+xZS
 bva
-bIX
-bDi
-bDi
+bTl
+bva
+bva
+bva
+bva
 bWZ
-bDi
-bWZ
-nWF
-ckm
-bDi
+jdr
+bva
+bva
 bva
 bva
 bva
@@ -72041,33 +71104,33 @@ bsK
 bAO
 jSW
 uPG
+bCa
+bOM
+doo
+vOw
 bSl
-tak
-dok
-rus
-bEr
 gjt
-sEN
+blE
 mxV
-fWl
-bLA
-uAs
-bQj
-bSp
-bTd
-mSr
+bKn
+bLz
+bMF
+bNL
+bOD
+aht
+bIZ
 cjf
 ewV
-bXa
-bRD
+aKf
+vGg
 cve
-sUP
+nSe
 bTf
-vGg
-vGg
+bRD
+bRD
 bVu
-bZt
 bOB
+ccN
 bva
 cab
 jPf
@@ -72299,20 +71362,20 @@ bAO
 eZM
 akb
 bSl
-bEr
-jnG
-bEr
-bEr
+bSl
+bSl
+bSl
+bSl
 gVY
-cld
-jVS
-ozc
-vbv
-bFJ
-iQW
-bFL
-bPy
-bQl
+oat
+sEN
+bKo
+bLA
+bMG
+bNM
+bOD
+aht
+bIZ
 txB
 bva
 bva
@@ -72324,7 +71387,7 @@ bva
 jYh
 bDi
 bDi
-kzj
+bSw
 bva
 kRq
 kRq
@@ -72517,7 +71580,7 @@ rlV
 aDZ
 aGV
 aDZ
-aDZ
+aSY
 aDZ
 aDZ
 aDZ
@@ -72555,18 +71618,18 @@ bsK
 bzG
 eZM
 uPG
-eZM
-fEZ
-eOe
-aCD
+bSl
+bKr
+fMe
 buk
 bEr
-dlS
-bEr
-bEr
-bEr
-bEr
-bEr
+erQ
+iMd
+bJm
+bKn
+bKn
+bKn
+bKn
 bEr
 aht
 bva
@@ -72812,21 +71875,21 @@ dAr
 uCe
 eZM
 aeF
-ulf
-fhc
-suU
-bkh
+bSl
+tal
+bBN
+rFq
 ahr
 sOB
-pDZ
-qhW
+sEN
+sEN
 vmo
-sHH
-ciZ
-hdk
-rXT
+bLA
+bMG
+bNM
+bOD
 aht
-bva
+bIZ
 fAe
 fnq
 xXe
@@ -73069,23 +72132,23 @@ bzI
 shv
 eZM
 uPG
-eZM
-abd
+bSl
+bWQ
 bGO
 bHU
-bJk
+bEr
 jKE
-feS
+iMd
 agl
-vsn
+bKn
 pOt
 ctt
-rHh
-bSs
+bNL
+bOD
 aht
 bIZ
-aLw
-bFZ
+nPm
+bva
 bSq
 bWH
 ckb
@@ -73326,24 +72389,24 @@ eZM
 eZM
 eZM
 ndP
-eZM
-fMi
-bGT
-boN
-bNj
-sOB
+bSl
+bEr
+bFi
+bEr
+bEr
+sea
 cLu
 qxU
-xgv
-piR
-lba
-sea
-bSs
+bKn
+bKn
+bEr
+bEr
+bEr
 aht
-bIZ
-sZP
 bva
+nPm
 bva
+bFZ
 bva
 bva
 bva
@@ -73584,21 +72647,21 @@ btV
 pzR
 uPG
 eZM
-wBU
-bGT
-cUz
-clK
-sOB
-vgg
+fEZ
+eOe
+aCD
+bEr
+rbg
+sEN
 nbt
-cSf
-jsD
+tjj
+bLA
 gsP
 kVM
 bOI
-aht
-bva
-sZP
+bTd
+mSr
+bAC
 bva
 bSu
 bTi
@@ -73840,24 +72903,24 @@ eZM
 bzL
 uPG
 uPG
-eZM
-jqA
-bGT
-aFa
-auB
-sOB
+uqs
+bkh
+gXg
+bkh
+bEr
+bFn
 bpz
 bOE
 cSf
 wGM
 pTy
 kYt
-bSs
-aht
-bIZ
-sZP
+auD
+bPy
+bQl
+aZE
 bRF
-bDi
+cvI
 bPC
 bDi
 bva
@@ -74096,25 +73159,25 @@ cpY
 eZM
 bCt
 qma
-lOK
+bCa
 eZM
-abd
-bGT
-bHY
+bBi
+gXg
+bNj
 acR
-sOB
-tbS
-aJY
-bNO
-uOA
-mMd
-uqs
-sOB
-aht
+bEr
+bEr
+bEr
+bEr
+bEr
+bBX
+bBX
+bBX
+bBX
 bva
-sZP
-bNK
-bSv
+aLw
+bPI
+bVY
 bTj
 bDi
 bva
@@ -74356,18 +73419,18 @@ bCf
 btZ
 eZM
 fGz
-acI
+suU
 bul
 tqC
-tqC
-tqC
-tqC
-tqC
+aci
+bkv
+jty
+jpa
+bKA
 bva
-ctb
-snZ
-bva
-bva
+qIl
+aIe
+uYT
 bva
 cwU
 bva
@@ -74613,17 +73676,17 @@ bCf
 anS
 eZM
 grE
-bGT
-cqm
+bpG
+bkh
 tqC
-bKr
-bLC
-ach
-ama
+nPg
+qUO
+bye
+bye
+bqr
 bva
-bNP
+bBe
 bvZ
-bTJ
 bwB
 bva
 sZP
@@ -74869,16 +73932,16 @@ brf
 bCf
 acf
 eZM
-abd
-bGT
-aci
+snm
+diT
+boN
 agE
 bzJ
 qUO
 bye
-bpG
+bye
+pFS
 omS
-nSe
 bUp
 nSe
 bcv
@@ -75117,7 +74180,7 @@ wUf
 bpY
 ixN
 kVN
-bpX
+bpY
 bpY
 bpY
 bpY
@@ -75126,16 +74189,16 @@ eZM
 bEv
 eZM
 eZM
-abd
-bGT
-cqm
+bjc
+diT
+cUz
 tqC
 bKt
 khw
 acr
 xhT
+cKF
 bva
-bNR
 pHN
 fAE
 jdr
@@ -75372,30 +74435,30 @@ bmp
 hhl
 hQv
 bjc
-mnE
-bsB
-jty
-bsA
+bkh
+bGT
+bjc
 byp
-iFy
+myc
+ahv
 ahu
 bCj
-ioj
-tAK
-bsA
-bFK
-bGT
-cqm
+uyZ
+bKp
+gld
+bjc
+diT
+bkh
 dJN
 acw
 bLE
-tFk
+cld
 bva
 bva
 bva
 bva
 bva
-amZ
+bNO
 bzO
 pWe
 neD
@@ -75629,25 +74692,25 @@ uVB
 kqm
 ble
 bjc
-abd
+bSM
 bGT
-cqm
-bsA
+bjc
 byp
-eER
 mqT
+uyZ
 eER
-ioj
-cec
-bsA
-abd
-bGT
-cqm
+eER
+uyZ
+pPN
+bMN
+bjc
+diT
+bkh
 mAi
-ehr
+lsq
 bye
 iTx
-bva
+ema
 bOF
 aAO
 aAO
@@ -75834,7 +74897,7 @@ iKm
 akD
 jfK
 uNI
-uNI
+oSa
 etD
 qgp
 atJ
@@ -75886,26 +74949,26 @@ tqO
 nwW
 uwj
 bjc
-vsv
+mdP
 bGT
-cqm
-bsA
-bYt
-rHG
-mmV
-rHG
-bEE
-adq
-bsA
 bZh
-bGT
-cqm
+pPN
+pPN
+bHT
+eER
+rHG
+uyZ
+pPN
+wKb
+bZh
+diT
+bkh
 anx
-ehr
+lsq
 bye
-bjQ
+hQh
 bva
-aLw
+bTN
 bBX
 bBX
 bBX
@@ -76091,9 +75154,9 @@ pln
 pln
 aqF
 apQ
-jrI
+aqF
 auF
-aoz
+jrI
 atK
 auJ
 aqE
@@ -76143,24 +75206,24 @@ bDy
 tCi
 xQO
 bjc
-bZh
+nwc
 bGT
-cqm
-kQy
-tSd
-mau
+ndU
+nKT
+bHT
+eZm
 krb
 eFj
 bCl
-bzR
-kQy
+hUF
+aMw
 abd
-bGT
-cqm
-tqC
-bEy
+diT
+bkh
+bpI
+nin
 lov
-bpi
+tFk
 bva
 eqL
 bBX
@@ -76347,7 +75410,7 @@ aaa
 aaa
 aaa
 aqF
-aqF
+afl
 aqF
 aqF
 aqF
@@ -76400,21 +75463,21 @@ agh
 bny
 bUt
 bpF
-brd
-bsC
+cCU
+fRs
 aes
-eRb
-bzR
-bzR
+knZ
+cuX
+eKg
 bzT
 bDw
 bEF
-byJ
-bEz
+bJh
+bON
 axE
-ami
-bMN
-mOx
+bKm
+vUO
+jOm
 apd
 arn
 vlV
@@ -76603,12 +75666,12 @@ amx
 aaa
 aaa
 aaa
-aht
-tqe
-cdm
 aqF
+tqe
+aqF
+anb
 asM
-aoz
+nTU
 auK
 cje
 aqF
@@ -76657,25 +75720,25 @@ pku
 vyL
 biY
 bjc
-acv
+aRi
 bGT
-aes
-eRb
-bzR
-bzR
-byo
+bGw
+wKb
+pPN
+bVk
+bVk
 aoR
-boc
 bzR
-buc
-fhc
-diT
-aes
-bpI
-bsF
+pPN
+wKb
+wTZ
+bKm
+bkh
+hBd
+ehr
 bye
-dAF
-ema
+bjQ
+bva
 amZ
 bBX
 bQo
@@ -76860,13 +75923,13 @@ agy
 aaa
 bHI
 aht
+bsF
 aht
-aht
-cdm
+bMD
 arC
 asN
 atM
-auK
+bMC
 avO
 aqF
 axU
@@ -76914,23 +75977,23 @@ jze
 jze
 jze
 bwC
-xqq
+bkh
 bGT
-cqm
+bAg
 bzV
+pPN
 bzR
-bld
-hQh
-bBe
-bCn
 bzR
+hMt
+bzR
+hZY
 bEA
-abd
-diT
-fhH
-tqC
+pOc
+bKm
+bkh
+bum
 idj
-bye
+alI
 bMK
 bva
 amZ
@@ -77119,11 +76182,11 @@ agy
 aaa
 aht
 aaa
-cdm
-aqF
-aqF
+bGI
+jNB
+bmd
 aoz
-auK
+ayF
 vrP
 aqF
 axV
@@ -77171,24 +76234,24 @@ awW
 bnB
 boF
 uSx
-xte
+bkh
 bGT
-xja
+bjc
 boB
-tWt
 pPN
+bzR
+bzR
+hMt
+bzR
 pPN
-pTD
-pPN
-wKb
 tcX
-abd
-diT
-cqm
-hBd
-rFq
-khw
-bPS
+bjc
+bKm
+bkh
+tqC
+tqC
+tqC
+tqC
 bva
 xkT
 bBX
@@ -77376,8 +76439,8 @@ agy
 aaa
 aht
 aaa
-aaa
-aaa
+bGI
+qSy
 aqF
 aqF
 aqF
@@ -77428,23 +76491,23 @@ bmv
 bnC
 vbR
 brg
-xqq
+bkh
 bGT
-fWq
+bjc
 bsA
-cqd
-pPN
-pPN
-bBf
-hZY
-tal
+bwO
+bNV
+ahZ
+bBg
+bCr
+kGl
 bsA
-abd
-diT
-cqm
-bum
+bjc
+bKm
+bkh
+bLS
 gkG
-bye
+adq
 bMM
 bva
 vfA
@@ -77632,9 +76695,9 @@ acg
 amx
 aaa
 aht
-aaa
-aaa
-aaa
+csv
+prT
+wWO
 arA
 atP
 auN
@@ -77652,7 +76715,7 @@ awR
 awR
 aHS
 aIS
-aJQ
+mey
 aKT
 aLK
 aNh
@@ -77685,26 +76748,26 @@ mRD
 bnD
 bTL
 diT
-qqQ
-bGT
-xja
-bsA
-xQr
-bpH
-pPN
-bBf
-bpH
-byv
-bsA
-abd
-diT
-cqm
-tqC
-bKA
-bPL
+iyj
+jxY
+bKi
+bKi
+bKi
+bKi
+bKi
+hRp
+sSl
+bOp
+alz
+dwI
+bOp
+bOp
+bOp
+bOp
 aek
-bva
-amZ
+aek
+ace
+cnE
 bPC
 bBX
 bRd
@@ -77888,7 +76951,7 @@ qar
 qar
 amx
 aht
-aht
+bVf
 aht
 arA
 arA
@@ -77942,26 +77005,26 @@ eus
 xIP
 vPE
 bsG
-xqq
-bGT
-cqm
-bvl
-bwO
-bNV
-ahZ
-bBg
-bCr
-kGl
-bvl
-fGz
-alI
-bul
-tqC
-tqC
-tqC
+bKm
+sJJ
+bkh
+bkh
+bkh
+ewd
+cco
+rfm
+aZq
+bkh
+bkh
+gOV
+bkh
+bkh
+bKm
+rfm
+cco
+bkh
 bva
-bva
-amZ
+aMc
 bPD
 bBX
 bRe
@@ -78145,7 +77208,7 @@ mDK
 dSI
 amx
 aaa
-aht
+bPc
 aaa
 aqI
 arH
@@ -78198,26 +77261,26 @@ lxx
 bmw
 tcV
 jze
-bjc
+mKE
 bxA
-bGT
-nYu
-oSa
+tQD
+bja
+acv
+acv
+bja
+akU
+bpW
 brh
-brh
-brk
-bkW
-brh
-brh
-brh
-xqq
-diT
+bDW
+akU
+akU
+bFU
 nYu
 ajf
 amo
-bLL
+nYu
 bva
-bNW
+bva
 bOH
 bva
 bBX
@@ -78402,7 +77465,7 @@ dSI
 hNl
 amx
 aaa
-aht
+bPc
 aaa
 aqI
 arI
@@ -78453,29 +77516,29 @@ mKE
 brm
 sLv
 rLU
-ulq
-ulq
+sLv
+sLv
 bJS
-vII
-bnu
-dRU
+ulq
+adH
+acv
 gzG
+buH
+bja
+bpX
+qEf
+gBt
+gOH
 dRU
-ahR
-dRU
-bBi
-dRU
-dRU
-dRU
-dRU
-aeJ
+cBK
+bFU
 gFf
-gFf
-gFf
-gFf
-ace
+adJ
+hxM
+bNl
+bva
 agz
-cnE
+aMc
 bva
 bQs
 bRg
@@ -78659,7 +77722,7 @@ acd
 nLa
 amx
 aaa
-aht
+bPc
 aaa
 aqI
 arJ
@@ -78711,27 +77774,27 @@ bke
 bys
 wQy
 bkg
-bys
+ajr
 tzM
 kye
-bsH
+voy
 eUA
 crd
-cqs
-bpW
+cAS
+ygT
 cqs
 qEf
 esz
 rCo
-cqs
-cqs
-beb
-cqs
-cqs
-prD
+bAD
+lya
+bFU
+bOA
+szK
+aYx
 prD
 bva
-bNU
+cdo
 aMc
 bPF
 lhK
@@ -78916,7 +77979,7 @@ acg
 acg
 amx
 aht
-aht
+bPc
 abI
 arA
 arK
@@ -78965,30 +78028,30 @@ aDZ
 aDZ
 cQN
 bkf
-ajr
-bmx
-bnE
-boK
-bjc
-bsI
-tkl
-bub
-bub
+rXT
+rXT
+bJb
+frX
+bld
+ufo
+kvU
+acv
+aFa
 ydL
-uYT
-buj
-bub
-bub
-bub
-bFU
+bja
+uYF
+bCx
+byw
+hBn
+bHD
 bEs
-bwu
+bFU
 aAL
-bEs
-bFU
-bEs
+prV
+aev
+iFy
 bva
-bva
+bNU
 aMc
 bva
 bQu
@@ -79148,14 +78211,14 @@ aaa
 aaa
 aaa
 aaa
-aht
 aaa
 aaa
-bBW
+aaa
+acO
 abI
-bBW
-bBW
-bBW
+abI
+abI
+abI
 abI
 aaa
 agy
@@ -79173,7 +78236,7 @@ bBF
 dSI
 agy
 aaa
-aht
+bPc
 aaa
 aqI
 arL
@@ -79221,30 +78284,30 @@ atO
 atO
 atO
 bjf
-cpX
-frX
-cqc
-bnF
-ufo
-ppW
-ufo
+bkf
+amt
+blp
+aTm
+xte
+bmy
+awX
 qnJ
-buj
-oKI
-aij
-bZe
-nsD
+bdR
+bdR
+bdR
+bdR
+bdR
 bjT
-bIa
+apj
 bub
 anT
 oBP
-bTN
-snT
-iha
+bFU
+bFU
+sWM
 fzB
-ans
-bAg
+bFU
+bFU
 bva
 aMc
 bva
@@ -79430,7 +78493,7 @@ acg
 qIv
 agy
 aaa
-aht
+bPc
 aaa
 aqI
 arM
@@ -79478,28 +78541,28 @@ atO
 bhN
 aDZ
 bmA
+tOk
+cqa
+buF
 ufo
-ahM
-bmy
-awX
 bmz
 cnC
-brj
-bsJ
-buj
+uAs
+ewZ
+iBq
 asB
-tEE
-byw
-hBn
+bnO
+mzp
+bdR
 aaR
-bCx
-bub
-bLM
-bFP
-bGZ
-bLP
-cKF
-bIb
+faL
+bva
+bva
+bva
+bva
+oKI
+adJ
+bLu
 bLP
 bAh
 bva
@@ -79641,36 +78704,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
-acO
-aaa
-aaa
-aby
-aaa
-acO
-abI
-aby
-aaa
-aaa
-aaa
 aby
 aby
-aaa
-aaa
-abI
-aaa
-aaa
+aby
+fon
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
 aaa
 aaa
 abI
 aaa
 aaa
 aaa
-acP
-acP
-acP
-acP
-acP
+aaa
+abI
+aaa
+aaa
+aaa
+gRv
+gRv
+gRv
+gRv
+gRv
 aht
 abI
 aaa
@@ -79687,7 +78750,7 @@ oNa
 ldB
 amx
 aaa
-aht
+bPc
 aaa
 aqI
 arN
@@ -79740,24 +78803,24 @@ blp
 bmz
 bnG
 vLM
-bja
-fgs
-bja
-bub
-uYF
+bdR
+bSs
+bSs
+bdR
+bmx
 tEE
-apj
-akU
-tjj
+ybu
+bdR
+bva
 bVg
-bub
+bva
 czd
 bFP
-bLP
-bLP
-bLP
-elL
-bLP
+bva
+jhw
+bPr
+vCE
+nCe
 ooh
 bva
 iga
@@ -79900,34 +78963,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
 abI
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
+abI
+rBu
 aaa
 aaa
 aaa
 abI
 aaa
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
+gRv
+gRv
+gRv
+gRv
+gRv
+gRv
+gRv
+gRv
+gRv
+gRv
+gRv
 aeY
 aft
 afK
-acP
+gRv
 aaa
 aby
 aaa
@@ -79944,7 +79007,7 @@ uaB
 psp
 amx
 aht
-aht
+amB
 abI
 arA
 arO
@@ -79997,24 +79060,24 @@ uKD
 ufo
 cqf
 cqp
-yat
+bSs
 pGi
 bsL
 buj
-auD
-qqX
+efJ
+eON
 adh
 umM
-tEE
-hMt
-bub
+bva
+bDi
+bva
 eBk
 bmt
-bDv
+bva
 qwJ
-mqg
-bKG
-byA
+bJd
+cuL
+eQD
 apK
 bva
 aMc
@@ -80155,36 +79218,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 epX
 epX
-mVM
-abO
-aht
-aaa
-aaa
-mVM
 epX
 epX
-abO
 epX
-acP
-ael
-aeB
-ads
-adH
-adS
+epX
+epX
+epX
+epX
+epX
+epX
+epX
+epX
+gRv
+dVK
+aaZ
+qvM
+kjK
+aee
 aee
 adZ
 aee
-aev
+aee
 kjK
 aeZ
 afu
 afL
-acP
+gRv
 abI
 aby
 aht
@@ -80201,7 +79264,7 @@ acg
 ifu
 amx
 aaa
-aht
+bPc
 aaa
 aqI
 arP
@@ -80251,26 +79314,26 @@ aDZ
 bji
 cQN
 blq
-amt
-blp
+ufo
+ufo
 aaW
-yat
+bSs
 hjy
 dOM
 qHa
+ruk
+fhH
 dVv
-dVv
-dVv
-dVv
-amc
-bBX
-bBX
+iha
+bva
+bDi
+bva
+bzi
 bva
 bva
 bva
 bva
 dOo
-bva
 bva
 bva
 bva
@@ -80412,36 +79475,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 abI
 epX
-mVM
-mVM
-aaa
-aaa
-aaa
-aaa
-mVM
-mVM
-mVM
-mVM
-mVM
-acP
-acX
+abO
+amz
+nYZ
+bBT
+bBT
+bOc
+wvM
+bNn
+bBT
+abO
+amz
+nYZ
+gRv
+agt
 adi
-ads
-acP
-acP
-aeh
-aeh
-aeh
-acP
-acP
+omU
+gRv
+gRv
+clm
+clm
+clm
+gRv
+gRv
 ads
 afv
 afM
-acP
+gRv
 aaa
 aaa
 aaa
@@ -80458,7 +79521,7 @@ tWf
 iqA
 agy
 aaa
-aht
+bPc
 aaa
 aqI
 arQ
@@ -80508,22 +79571,22 @@ cpN
 cpT
 cQN
 blr
-cqa
-ufo
+brj
+brj
 boO
-yat
+bSs
 khJ
 kEb
-bja
-aoX
+cqG
 cIe
-ihJ
-phx
-bCB
-bCB
+cIe
+cIe
+cIe
+snZ
 bmf
 bmf
 bmf
+bZe
 bmf
 bmf
 bmf
@@ -80669,38 +79732,38 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-abI
-aaa
-abO
-mVM
-mVM
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-mVM
-mVM
-mVM
-acP
+epX
+bOc
+sqZ
+ajk
+ajk
+ajk
+ftb
+bsI
+bsI
+bsI
+bsI
+sqZ
+bNn
+gRv
 acX
-adr
-ads
-acP
-cnD
-cnD
-cnD
-cnD
-cnD
-acP
-ads
-acP
-acP
-acP
-agq
-acP
+lcO
+bLt
+gRv
+aaa
+aaa
+aaa
+bBW
+bBW
+gRv
+voX
+gRv
+gRv
+gRv
+adN
+adI
 aaa
 aht
 aaa
@@ -80715,7 +79778,7 @@ amx
 agy
 agy
 aaa
-aht
+bPc
 aaa
 aqI
 arR
@@ -80776,8 +79839,8 @@ bwW
 ppx
 dsH
 fby
-ahK
-bCB
+bva
+bmf
 bva
 bva
 bva
@@ -80926,53 +79989,53 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-aht
-mVM
-mVM
-acP
-acP
-acP
+epX
+aae
+ajk
+ajk
+epX
+epX
+epX
+ptV
+epX
+epX
+bsI
+bsI
+bGf
+gRv
+gRv
+gRv
 adv
-acP
+gRv
 adW
-bHq
+ack
 cnH
-bHq
+ack
 aex
-acP
+gRv
 afc
-acP
+gRv
 afN
 age
 agr
-acP
-aaa
+adI
 aht
 aht
 aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bPc
 abI
 arA
 arA
@@ -81034,7 +80097,7 @@ bva
 bva
 bva
 bva
-bCB
+bmf
 hVx
 xDj
 bva
@@ -81042,15 +80105,15 @@ jCv
 bOK
 bEN
 bKI
-bEN
-bHf
+abg
+fjc
 bOa
-bOK
+oAc
 bPG
 bQB
 bHf
 bRV
-bSM
+bQD
 bTC
 bUi
 bUV
@@ -81101,7 +80164,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abN
 aaa
 aaa
 aaa
@@ -81183,40 +80246,40 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aht
-mVM
-mVM
+epX
+bBT
+ajk
+epX
+epX
+epX
+epX
+ptV
+epX
+epX
+epX
+bsI
+bBT
 epX
 add
 adk
-adw
-acP
-cnD
-cnD
-cnD
-cnD
-cnD
-acP
+vsv
+adI
+bBW
+bBW
+aaa
+bBW
+bBW
+adI
 acY
 afw
 afO
 agf
 ags
-acP
-acP
-acP
+adI
+adI
+adI
 aaa
 aht
 aaa
@@ -81229,7 +80292,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+bPc
 aaa
 aaa
 aaa
@@ -81299,15 +80362,15 @@ bAk
 bIt
 bxJ
 cqx
-bxJ
-bxJ
-bxJ
-bxJ
+bJe
+bJe
+bJe
+bJe
 bPH
 bQC
-bxJ
+bJe
 arl
-bSM
+bQD
 bTC
 bUj
 bUW
@@ -81440,39 +80503,39 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+epX
+bBT
+ajk
+epX
+epX
+acN
 qxs
-mVM
-aaa
-aaa
-aaa
-mVM
-mVM
-mVM
+rHh
+epX
+epX
+epX
+nWF
+bBT
+bPp
 add
 adl
 adx
-acP
-acP
-aeh
-aeh
+adI
+adI
 adN
-adP
-adP
+adN
+adN
+adI
+adI
 afe
 afx
 afx
-afx
-acP
-acP
-acP
+uZJ
+adI
+adI
+adI
 ahh
 abI
 aht
@@ -81486,7 +80549,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+bPc
 aaa
 aaa
 aaa
@@ -81556,15 +80619,15 @@ bAl
 bIu
 bmC
 bKK
-bLV
-bMT
-bOc
-cCU
-bmC
-tqE
-bmC
-tOk
-bSM
+bQD
+bQD
+amO
+amO
+amO
+amO
+amO
+rNJ
+bQD
 bTC
 bUk
 bUX
@@ -81613,7 +80676,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+aaa
 aaa
 aaa
 aaa
@@ -81697,37 +80760,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abN
-aaa
-aaa
-aaa
-aaa
-aaa
-mVM
-mVM
+aby
+bSS
+epX
+bBT
+lIy
+epX
+epX
+pGM
+rMV
+aUq
+bTR
+epX
+epX
+aTl
+agq
+bMT
 adb
-adw
+aWs
 adw
 adM
 adY
 adK
+xlD
 adK
 adK
-aey
 aeO
 aff
 afy
 afP
-gup
-agt
+agf
+agR
 agD
 agR
 ahi
@@ -81742,10 +80805,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aht
-aaa
-aaa
+amB
+cdm
+cdm
 cdm
 ahi
 atZ
@@ -81809,18 +80872,18 @@ bCD
 bDA
 ccN
 jSA
-bHo
+acA
 bRX
 bJD
 qOx
-bMU
-ahV
+qOx
+qOx
 bOL
-bOf
-qOx
-qOx
-qzm
-xGi
+hwj
+jHZ
+cCV
+bPq
+rNJ
 bSN
 bTD
 bTC
@@ -81954,39 +81017,39 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-abI
-aaa
-mVM
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aht
-aaa
-mVM
-mVM
-mVM
+epX
+bBT
+ajk
+epX
+epX
+acN
+bqv
+btY
+epX
+epX
+epX
+kWo
+bBT
+bPp
 add
 adn
 adz
 adI
 adI
-adJ
-aeh
-aeh
-acP
-acP
+adN
+adN
+adN
+adI
+adI
 afg
 afz
-cqH
+afz
 agg
-acP
-acP
-acP
+adI
+adI
+adI
 ahh
 abI
 aht
@@ -81999,8 +81062,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aht
+wwp
 aaa
 aaa
 aaa
@@ -82069,14 +81132,14 @@ bBX
 bvD
 bRX
 cqz
-qzm
+cNI
 bLR
 bMV
-bOd
+bRp
 hwj
 bPK
 cCV
-bRp
+amO
 rNJ
 iqI
 pps
@@ -82211,52 +81274,52 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-aaa
-aaa
-mVM
-mVM
-aht
-aaa
-mVM
-aht
-aht
-aaa
-aaa
-aaa
-mVM
-mVM
+epX
+bBT
+ajk
+epX
+epX
+epX
+epX
+oLw
+epX
+epX
+epX
+bRr
+bBT
 epX
 add
 ado
-adw
-acP
-cnD
-cnD
-cnD
-cnD
-cnD
-acP
+aWs
+adI
+bBW
+bBW
+aaa
+bBW
+bBW
+adI
 otI
 afA
 afQ
 agf
 ags
-acP
-acP
-acP
+adI
+adI
+adI
 aaa
 aht
-aaa
-aaa
-aaa
-aaa
-cFB
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+bTM
+aht
+aht
+aht
+aht
+aTs
 aht
 aaa
 aaa
@@ -82326,13 +81389,13 @@ bBp
 bHh
 bIv
 cqz
-qzm
-bLS
+kRs
+bLR
 bPJ
-ceb
+amO
+hwj
 mYW
-mYW
-mYW
+cCV
 bRo
 bRY
 bSO
@@ -82468,52 +81531,52 @@ aaa
 aaa
 aaa
 aaa
+aby
 aaa
-aaa
-aaa
+epX
 abO
-mVM
-aaa
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aht
-mVM
-mVM
+ajk
+ajk
+epX
+epX
+epX
+bLT
+epX
+epX
+bRr
+bRr
+nYZ
 acP
 acP
 acP
 adB
 acP
-adW
+sKo
 ack
 cnH
-bHq
+ack
 aez
 acP
 afi
 acP
 afR
+aVp
 agu
-agu
-aeh
-aaa
-abI
+nwu
+cry
+cry
+cry
+wFW
+cry
+cry
+cry
+wFW
+cry
+cry
+cry
+wFW
+prT
 aht
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 app
 apT
 apT
@@ -82584,12 +81647,12 @@ bHi
 bRX
 cqz
 qzm
-bLT
-bPJ
+bLU
+yeF
 hyA
 amO
 amO
-amO
+aat
 kDa
 ovX
 gXQ
@@ -82605,7 +81668,7 @@ bZI
 cam
 cam
 cam
-cam
+jPo
 vXt
 jbG
 lXk
@@ -82725,52 +81788,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 epX
-mVM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-mVM
-mVM
-mVM
+bOc
+sqZ
+ajk
+ajk
+ajk
+cnD
+bRr
+bRr
+bRr
+bRr
+sqZ
+bNn
 acP
 ade
 aeB
-ads
+bUv
 acP
-cnD
-cnD
-cnD
-cnD
-cnD
+aaa
+aaa
+aaa
+bBW
+bBW
 acP
 afk
 acP
 acP
 acP
-agq
-acP
-aaa
+adN
+adI
+abI
 abI
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aht
 apT
 aqL
@@ -82840,13 +81903,13 @@ bBp
 bHj
 bIx
 cqz
-qzm
+uEQ
 bLU
 bMW
 bOe
-bYs
+bQD
 bPM
-bOM
+bQD
 bQD
 bCC
 bSP
@@ -82859,10 +81922,10 @@ bXk
 bXk
 bZc
 bZJ
-cam
-cam
-cam
-jPo
+hsx
+cZF
+rtE
+aey
 ory
 jbG
 tJe
@@ -82982,24 +82045,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abI
+aby
 abI
 epX
-mVM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-mVM
-mVM
-mVM
-mVM
+aae
+nwg
+bGf
+bBT
+bBT
+bOc
+oqI
+bNn
+bBT
+aae
+nwg
+bGf
 acP
 adf
-adi
+nOE
 adD
 acP
 acP
@@ -83008,7 +82071,7 @@ aeh
 aeh
 acP
 acP
-afk
+bCU
 adS
 adU
 acP
@@ -83016,8 +82079,8 @@ aaa
 aaa
 aaa
 abI
-aaa
-aaa
+aht
+aht
 aaa
 aaa
 aaa
@@ -83103,10 +82166,10 @@ bMU
 bOf
 qOx
 qOx
-qOx
-qzm
+bdM
+qhW
 aAb
-qzm
+qOx
 bJN
 bJN
 bVd
@@ -83239,35 +82302,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
-mVM
 epX
-abO
-aaa
-aaa
-aht
-aht
-mVM
 epX
-abO
-mVM
+epX
+epX
+epX
+epX
+epX
+epX
+epX
+epX
+epX
+epX
 epX
 acP
 adg
 adr
-ads
+xKD
 adQ
-aec
+afk
+afk
+cMu
+afk
+afk
+adQ
+afk
 ael
-ael
-ael
-aeB
-aeS
-afl
-ael
-ael
+adU
 acP
 abI
 aby
@@ -83355,19 +82418,19 @@ bHl
 bRX
 cqD
 bKO
-bON
+bPP
 bMY
 bOg
 bOO
 bPN
 bQF
-bRs
+aRq
 bSb
-bRs
+bPP
 bvi
 bUy
 bTH
-xZS
+bRs
 bVe
 bVV
 bWI
@@ -83498,22 +82561,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-acO
-aaa
+abI
 aaa
 aaa
 aaa
 aaa
 aaa
+abI
+bxD
 aaa
 aaa
 aaa
-acF
-acN
-adP
-adP
-adP
+aht
+aaa
+acP
+acP
+acP
 adP
 acP
 acP
@@ -83602,30 +82665,30 @@ cCl
 bqb
 bxh
 bqb
-fRs
-fRs
+bBp
+bBp
 bAo
 bAo
-fRs
+bBp
 bBp
 bHo
-bRX
-cqD
-bKO
+axl
+ciZ
+xae
 bLX
 bMZ
 bOh
 bOP
-bQI
+bts
 bNc
 bNc
 bSc
-bNc
+aXA
 bUq
 bUq
 bUq
 bUq
-bVf
+bUq
 agN
 bWJ
 bOs
@@ -83633,7 +82696,7 @@ bQI
 bkc
 aiv
 bLW
-bGr
+abI
 bJP
 bJP
 bJP
@@ -83753,25 +82816,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
+aby
+aby
+fon
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aaa
+aaa
 abI
-aby
-aby
-aby
 aaa
-aaa
-aaa
-aaa
-aaa
-acO
-aby
-aby
-aaa
-aaa
-abI
-aaa
-aaa
+auB
 aaa
 aaa
 abI
@@ -83869,23 +82932,23 @@ cqw
 bHn
 cqD
 bKO
-bPI
+bPP
 bNa
-bOn
-bMf
-bPP
+bfI
+hHv
+btp
 bQG
-bMf
-bSd
+jsj
+xne
 bPP
-bMg
+bMf
 bMf
 bMf
 qvH
-amz
-bVY
-bWM
 bMf
+bWa
+bWM
+bMB
 fuR
 bPW
 bZO
@@ -84024,7 +83087,7 @@ aaa
 aaa
 aaa
 aaa
-acO
+nge
 aby
 aby
 aby
@@ -84125,29 +83188,29 @@ bBz
 bHr
 bID
 bJH
-bJN
-bJN
+bST
+bST
 bNb
 bOj
-amz
-bPQ
-aeG
-aaZ
-aeG
-bPQ
-bpq
+bST
+bST
+bST
+bST
+bST
+bST
+aef
 jWH
-bTK
-bUr
-bPQ
-bVW
-bWM
 bMf
+bMf
+bMf
+bWa
+bWM
+bSd
 bPW
 bMf
 ajU
 bLW
-bGr
+abI
 bMi
 caA
 cbt
@@ -84382,22 +83445,22 @@ bko
 bHs
 rBg
 cqE
-baw
-bJN
-bLY
-bOn
+bST
 aKN
-bST
-bST
-bST
-bST
-bST
+bLY
+ouY
+aaH
+fhc
+kWc
+bNt
+kzj
+bNt
 aef
 urG
-urG
-urG
-bST
-bvm
+bMf
+bMf
+bMf
+bWa
 bWM
 bNh
 aQf
@@ -84542,7 +83605,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -84638,30 +83701,30 @@ bEZ
 bHp
 bHt
 bJJ
-auL
-bzc
+bST
+bST
 bPa
 bLZ
-bOn
+cuY
+bOZ
+bOZ
+bOZ
+bOZ
+bOZ
+bOZ
+pBm
 bMf
-voX
-bPR
-ntO
-xne
-bGg
-ajk
-aNL
-aNL
-aNL
-avP
-bVY
+bMf
+bMf
+bMf
+bWa
 bWM
 bNh
 bPW
 bOn
 ahI
 bLW
-bGr
+abI
 bJP
 bJP
 bJP
@@ -84861,15 +83924,15 @@ aGV
 vif
 fTh
 pvZ
-ndU
-jNK
-cxJ
 pvZ
-cMu
-aDZ
-qvM
-aDZ
-aaO
+jNK
+pvZ
+pvZ
+pvZ
+aEj
+aEj
+aEj
+aEj
 aDZ
 aDZ
 aDZ
@@ -84895,23 +83958,23 @@ bCO
 bBo
 bCO
 bBo
-bwm
-oFj
+bST
 aRl
+ciJ
 bMa
-bOn
+bOZ
+bOZ
+bOZ
+bOZ
+fgs
+bOZ
+bOZ
+pBm
 bMf
-bOW
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-xgP
-bVY
+bMf
+bMf
+bMf
+bWa
 bWM
 bNh
 bWK
@@ -85117,15 +84180,15 @@ aPT
 aDZ
 aVq
 aWt
-aWs
-dOd
-aOV
-jdj
 aBP
-veM
-aDZ
+dOd
+qZN
+jdj
+jiO
+aUZ
+aEj
 onj
-aDZ
+aFi
 qEN
 aDZ
 aDZ
@@ -85152,30 +84215,30 @@ aaa
 aht
 aht
 aaa
-bwm
+bST
 jcQ
-aRl
+aeJ
 bMb
-bOn
-bOn
+hZZ
+rNB
 bOW
+bOW
+bOW
+lGX
 bOZ
-bOZ
-bRx
-bQJ
-bPX
-bOZ
-bOZ
-bOZ
-xgP
-bVY
+pBm
+bMf
+bMf
+bMf
+bMf
+bWa
 agp
 bNh
 bEw
 agi
 iKE
 bLW
-bGr
+abI
 bMi
 caD
 cbv
@@ -85375,15 +84438,15 @@ aDZ
 aVq
 aWt
 aXs
-bat
+aOV
 jJn
-rWv
+bat
 aMe
-qEm
-aSY
-aDZ
-aDZ
-tOf
+aMd
+aEj
+aFi
+wgM
+aEj
 bgC
 bgC
 bhQ
@@ -85409,23 +84472,23 @@ bCP
 bvC
 bCP
 bvC
-aRl
+bST
 avN
-bKR
+bFk
 bMc
-bNg
-bOn
-bOW
+cqm
+gQa
+bRx
+bQJ
+bPX
+vQz
 bOZ
-bOZ
-brl
-bCp
-beP
-bOZ
-bOZ
-bOZ
-xgP
-bVY
+pBm
+bMf
+bMf
+bMf
+bMf
+bWa
 bMg
 bNh
 bPW
@@ -85634,13 +84697,13 @@ aWt
 anQ
 aYp
 oYq
-bbB
-pvZ
-pvZ
+bat
+luW
+aWW
 aEj
-gOH
+aFi
 aEj
-beI
+aEj
 bgD
 bgD
 beI
@@ -85666,30 +84729,30 @@ bGe
 bGe
 bIE
 bIE
-aRl
+bST
 oDF
-aRl
-bMd
-bOn
-bOn
-bOW
+bFk
+bMc
+bBJ
+gQa
+brl
+bCp
+beP
+vQz
 bOZ
-bOZ
-bPX
-bQK
-bRx
-bOZ
-bOZ
-bOZ
-xgP
-bVY
+pBm
+bMf
+bMf
+bRz
+bMf
+bWa
 bMg
 bNh
 bPW
 bOn
 cbw
 bLW
-bGr
+abI
 bJP
 bJP
 bJP
@@ -85882,18 +84945,18 @@ aMj
 iKb
 btl
 dMB
-aLf
-bdR
-ndt
-aOT
-uZJ
-php
+aDZ
+icX
+aDZ
+aDZ
+aVq
+aWt
 vZP
-iOi
+aOV
 aZn
 bax
-cuL
-aUZ
+gVB
+bXv
 aEj
 aFi
 aEj
@@ -85916,31 +84979,31 @@ bvI
 bxw
 byQ
 bAA
-aPV
+veM
 bEY
 beD
 bBG
 bBG
 aHu
 aHu
-aRl
-xXA
-aRl
-bXw
-bOn
+bST
+bGv
+bFk
+bMc
+ceb
+gQa
+bPX
+bQK
+bRx
+vQz
+bOZ
+pBm
 bMf
-bOW
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-xgP
-bVY
-bTP
+bMf
+bMf
+bMf
+bWa
+bMg
 bNh
 bPW
 bOn
@@ -85996,7 +85059,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+aaa
 aaa
 aaa
 aaa
@@ -86141,16 +85204,16 @@ aOS
 lAs
 sBf
 aSe
-aSe
+cHp
 bMl
 apL
-aSe
+php
 pvZ
 bWT
 aYu
 aYr
-gVB
-aMd
+nBt
+aaI
 aEj
 qgq
 aEj
@@ -86176,34 +85239,34 @@ bAA
 cCO
 bBx
 bFd
-bCR
+bFd
 bCR
 bCR
 vRk
-aRl
-acy
-aRl
-bKT
-bOn
+bST
+lOK
+bFk
+bMc
+bNG
 bRw
-apf
 bpR
-uyF
+bpR
+bpR
 wtj
-bFM
+bOZ
 pBm
-bSS
-bTR
-gbu
-rvH
-bWa
+bMf
+bMf
+bMf
+bMf
+uyF
 bMg
 bNh
 bPW
 bMf
 asu
 bLW
-bGr
+abI
 bMi
 caG
 cbx
@@ -86391,18 +85454,18 @@ aET
 hFy
 aJh
 atO
-baC
-baC
-baC
-baC
-baC
-aRi
-aSf
-abg
-bgB
-aRj
+wDZ
+wDZ
+wDZ
+wDZ
+wDZ
+wDZ
+wDZ
+wDZ
+xja
+ilh
 jzL
-aWw
+pvZ
 aFu
 aYu
 bat
@@ -86432,33 +85495,33 @@ bod
 bAA
 brJ
 bXy
+bCR
 bFd
+bCR
 bHu
 bCR
-bCR
-bCR
-bKU
-acy
 pIh
-vmB
-alz
-aiX
-bST
-bST
-bST
-urG
-urG
-urG
-bST
-bST
-bST
-bST
-btY
+bOZ
+bFk
+bMc
+bOZ
+bOZ
+bOZ
+bOZ
+bOZ
+bOZ
+bOZ
+pBm
+bMf
+bMf
+bMf
+bMf
+bQL
 bMg
 bNh
 aea
-bKp
-abW
+bOn
+fis
 agc
 uPA
 bZN
@@ -86478,7 +85541,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -86648,23 +85711,23 @@ aHn
 aIi
 aBJ
 atO
-baC
-aVw
-cJZ
+wDZ
+nMF
+aMv
 cbF
-baC
+bSg
 oOm
-bgB
-bgB
-bgB
-aRj
+ijQ
+aTo
+ahV
+vxp
 vaa
 pvZ
 tQP
-aYu
-bat
-nBt
-bXv
+aLl
+bgB
+bbD
+bdw
 aEj
 wAC
 aEj
@@ -86689,48 +85752,48 @@ fgT
 bAA
 ccp
 bDL
+bCR
 bFd
+eWU
 aBQ
-cco
-bIF
 bHw
-aRl
+bST
 aly
-aRl
-bKV
-bOj
-amz
-bPQ
+bFk
+bMc
+bOZ
+bOZ
+apf
 nUq
 mIW
+bkW
 bQM
-bQM
-bQM
+aef
 qIn
 bTT
-bTS
-bPQ
-sqZ
+bMf
+bMf
+bQL
 bMg
 bNh
 bPW
 bwx
-bYw
-bYw
-bYw
-bYw
-cBT
-bYw
-bYw
-bYw
-bYw
-bYw
-abI
-gYo
+cbw
+bLW
+aht
+bJP
+bJP
+bJP
+bJP
+bJP
+aht
 aaa
 aaa
 aaa
-cFB
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86905,23 +85968,23 @@ aET
 xvO
 aBJ
 atO
-baC
+wDZ
 uVD
 ugy
-ugy
-wTv
+aTk
+aTk
 bdQ
-aTg
-aTg
-aUq
-aRj
-kWo
+qXb
+aTo
+bat
+vxp
+bbB
 pvZ
 qpv
 aYu
-bat
-nBt
-aWW
+sPZ
+aEj
+aEj
 aEj
 aFi
 aEj
@@ -86946,44 +86009,44 @@ aba
 bAA
 bCQ
 bDN
+bCR
+bFd
 bFb
-aBQ
-acs
-aRl
-aRl
-aRl
+fYY
+pdW
+bST
 bwS
-aRl
-bKW
-ahv
+bFk
+bMc
+bMc
 bPU
-bOp
-bQL
-bQL
-bQL
-afr
-bSg
-bQL
-bQL
-bQL
-bPc
+aef
+aef
+aef
+aef
+aef
+aef
+bPQ
+bPQ
+jMC
+bMf
 bQL
 bMg
 bNh
 bPW
-bZf
-bYw
-caI
-cbA
-aae
-aac
-rfm
-dVK
-dVK
-bIP
-amS
-abI
-gYo
+vzp
+jIM
+bLW
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87162,25 +86225,25 @@ aET
 xvO
 aBJ
 aNE
-baC
+wDZ
 aOW
-bcL
+aTk
 mri
-baC
+iUV
 gRU
 bDM
-aVp
-bgB
-aRj
-aRj
+aTo
+bat
+cpX
+rKN
 sAD
 lct
-aYu
+lct
 krI
-nBt
-aWW
-aEj
-aFi
+bGL
+dWw
+dWw
+rax
 aEj
 bfA
 bgJ
@@ -87203,43 +86266,43 @@ byU
 bAA
 bCQ
 bDN
+bCR
+bLv
 bDP
-aBQ
-acB
-aRl
+qtA
 rvO
 jIr
-acy
-aRl
-cqG
-bOn
-bOn
+rEd
+bFk
+xFG
+mDq
+air
+aef
+kLA
+kLA
+kLA
+uFr
+uFc
+fGF
+bPQ
+mOx
 qvH
-bMf
-bPb
-uFc
-uFc
-uFc
-bRz
-bMf
-bMf
-bUv
-bMf
+bQL
 bMg
-voR
-bYu
-bZg
-nnf
-amk
-aPb
-aPb
-aPb
-wLq
-aPb
-aPb
-fno
+bNh
+bPW
+bKR
 bYw
-aaa
+bYw
+bYw
+bYw
+cBT
+bYw
+bYw
+bYw
+bYw
+bYw
+abI
 gYo
 aaa
 aaa
@@ -87419,25 +86482,25 @@ aPR
 coy
 aBJ
 atO
-baC
+wDZ
 nWO
 osv
 fgv
-baC
+ddJ
 aQa
 eVr
 iJm
 bgB
 aRj
-bgB
+cqA
 aWw
+aUj
 aOV
-aZo
 kee
-bbD
-bdw
 aEj
-wgM
+aFi
+aFi
+bHA
 aEj
 aEj
 aEj
@@ -87459,43 +86522,45 @@ bxw
 byV
 bAA
 bAA
+bAA
 bCS
 bDQ
 bCS
 bAA
-aRl
-acy
-acy
-acy
-aRl
-bKY
+bAA
+bST
+bST
+bST
+bST
 bMh
-bOn
+bFM
+aef
+bQL
+afr
+bQL
+bQL
+bQL
+bQL
+mza
+bQL
+bQL
+bQL
+bMg
+bNh
 bPW
-bPe
-bNh
-bNh
-bNh
-bNh
-bSV
-bNh
-bNh
-bVk
-bNh
-bNh
-bNh
-bPW
-hvR
-uvq
-amk
-aPb
-oMk
-ayJ
-usl
-usl
-oMk
-apl
+bZf
 bYw
+caI
+cbA
+bLV
+aac
+ekO
+bwm
+aeG
+bIP
+amS
+abI
+gYo
 aaa
 aaa
 aaa
@@ -87529,9 +86594,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+abN
 aaa
 aaa
 aaa
@@ -87676,24 +86739,24 @@ aDZ
 aDZ
 aJk
 aJN
-baC
-oRX
-eHy
+aEj
+bct
+aEj
 wDZ
-wDZ
-wDZ
+aTo
+eEJ
 aTo
 wDZ
 aUu
 aTg
-bgB
+aBP
 pvZ
-xdY
-aOV
+rMn
+rMn
+pvZ
 aEj
-uwF
 aEj
-aEj
+oLk
 jwM
 dWw
 rud
@@ -87714,47 +86777,47 @@ buy
 bvO
 bCo
 dsa
-bAC
+bCT
+ccn
 bBH
 bCT
 bDR
-bCT
-bGj
-rNB
+vmB
+bXw
 xXA
-lWy
-omU
-omU
-kvU
-bKT
-bOn
-bPW
-nnl
-bPd
-bPW
-bQN
-bPW
-bPd
-bPW
-bTU
-bUx
-bPd
-bPW
-bvY
-bPW
-fis
-bYw
-bCi
-aPb
-oMk
-oMk
-lRS
-usl
-oMk
-cYQ
-bYw
-aht
+amp
 aaa
+aht
+kqA
+eEz
+bNh
+aiX
+bQL
+bPb
+bMf
+bMf
+bMf
+bMf
+bMf
+bMf
+bNI
+bMf
+bMg
+voR
+bYu
+bZg
+nnf
+amk
+aPb
+aPb
+aPb
+wLq
+aPb
+aPb
+fno
+bYw
+aaa
+gYo
 aaa
 aaa
 aaa
@@ -87932,26 +86995,26 @@ aMA
 aMA
 aMA
 alp
-aKf
-wDZ
-wDZ
-wDZ
-wDZ
-bBT
-bGf
+atO
+aEj
+bcI
+aEj
+beH
+cCB
+iIB
 qof
-wDZ
+aOT
 acj
 bII
-acj
-pvZ
-rMn
+cCB
+cxJ
+bzc
 pfe
+tDQ
 aEj
-aFi
 bfB
-oLk
-nTU
+aFi
+aQk
 aEj
 aEj
 aEj
@@ -87971,46 +87034,46 @@ bod
 bvP
 bxy
 bHE
-bAD
 bBI
-bCU
+udR
+bBI
+bBI
 bDS
 bwb
-bGk
-rNB
-acy
-lWy
-rNB
+bGo
+xPa
+amp
+aaa
 aht
-kvU
-arD
-bNn
-bWd
-jsj
-bOl
-ajZ
-bWd
-bLa
-ape
-axF
-bWd
-bVm
-ezx
-jiD
-bWd
-jsj
-abW
-bYw
-mSc
+aph
+bNh
+bNh
+bPW
+bPe
+bNh
+bNh
+bNh
+bNh
+bSV
+bNh
+bNh
+bYs
+bNh
+bNh
+bNh
+bPW
+hvR
+uvq
+amk
 aPb
 oMk
-oMk
-cbC
-fbC
+ayJ
 usl
-bbJ
-dVI
-ahm
+usl
+oMk
+apl
+bYw
+aaa
 aaa
 aaa
 aaa
@@ -88190,25 +87253,25 @@ aEd
 aIj
 aJm
 aKg
-wDZ
-aLl
-aTm
+aEj
+bcI
+aEj
 bBy
+cCB
+iIB
 aYh
-aYh
-aYh
-rax
-pIa
-hsx
-cqA
-pyl
-gyj
-gyj
-pLq
-rud
-rud
-rud
-bhq
+iIB
+iIB
+aYz
+cCB
+cCB
+baB
+baB
+cCB
+eGk
+aFi
+aFi
+aFi
 sYp
 aEj
 iDT
@@ -88225,60 +87288,49 @@ bqo
 brG
 btg
 fjs
-bwa
+tOf
 bvN
+bwa
 bUw
-bAE
-bBJ
-bBJ
+cgO
+bFf
+bFf
 bDT
 bFf
-bGl
-rNB
+bFf
 aRo
-lWy
-rNB
+amp
+aaa
 aht
-kvU
-bKZ
-kqA
-bWR
-kqA
-bVl
-pGj
-bWR
-pGj
-bVl
-pGj
-bWR
-bUz
-bVl
-pGj
-bWR
-kqA
-amV
-mXa
-hUX
-cYq
-mOH
-igl
-adC
-aYi
-aYi
-uEY
+aph
+bKT
+bMf
+bPW
+nnl
+bPd
+bPW
+bQN
+bPW
+bPd
+bPW
+bTU
+bUx
+bPd
+bPW
+bvY
+bPW
+fis
 bYw
-aaa
-gYo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bCi
+aPb
+oMk
+oMk
+lRS
+usl
+oMk
+cYQ
+bYw
+aht
 aaa
 aaa
 aaa
@@ -88286,23 +87338,34 @@ aaa
 aaa
 aaa
 aaa
-cju
-cju
-cju
-cju
-cju
-cju
-cju
 aaa
 aaa
 aaa
 aaa
 aaa
-cju
-cju
-cju
-cju
-cju
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88447,25 +87510,25 @@ aEd
 aEd
 aJn
 aEd
-wDZ
-rBu
-urZ
+aEj
+bcI
+aEj
 abh
-aRn
+aTq
 abe
-aTk
-aTo
-aUv
-eGk
 cCB
-aWB
+cCB
+cCB
+aYz
+cCB
+cCB
 baB
 bFu
+bMA
 aEj
 aEj
 aEj
 aEj
-jHZ
 aEj
 aEj
 aEj
@@ -88480,52 +87543,51 @@ bnW
 bpe
 bqp
 bqs
-aaM
-anb
-aaQ
+bqs
+bqs
+tOf
 bvN
-bts
+bwa
+bNp
 bAF
 bAF
 bCV
 bDU
 bCV
 bAF
-aRl
-acy
-bwm
-bwm
-abI
-aph
-ftb
-bGr
-aYB
-bGr
-ftb
-bGr
-aYB
-bGr
-ftb
-bGr
-aYB
-caQ
-bTM
-caQ
-bnc
-caQ
-sCf
-qXu
-qXu
-bZi
-bZR
-caL
-qHB
-bYw
-eml
-cdk
-bYw
+afj
+afj
+afj
 aht
-fon
+aph
+arD
+bGr
+bWd
+bNF
+bOl
+ajZ
+bWd
+bLa
+ape
+axF
+bWd
+bVm
+ezx
+jiD
+bWd
+caQ
+abW
+bYw
+mSc
+aPb
+oMk
+oMk
+cbC
+fbC
+usl
+bbJ
+dVI
+ahm
 aaa
 aaa
 aaa
@@ -88543,24 +87605,25 @@ aaa
 aaa
 aaa
 aaa
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88700,23 +87763,23 @@ aEe
 xPY
 aFG
 tfc
-ahB
+rWv
 ahB
 alx
 aKh
-wDZ
-gRv
-ddJ
-aOZ
+aEj
+bcI
+aEj
+aTp
 bcS
-aaJ
-aTl
-aTo
-aSk
+aTq
+cCB
+cCB
+cCB
 nif
 cCB
-jOm
-ayF
+cCB
+baB
 tXL
 asO
 bbK
@@ -88737,52 +87800,52 @@ bnX
 eSL
 bqq
 bpf
-aaK
-afb
-axu
+bpf
+qwP
+bKZ
 axu
 bza
+aWu
 bAF
 bBK
 bCW
-bDV
-bFh
-bGm
-aRl
-acy
+bsn
+bFl
+kTU
+aRp
 btS
-bwm
-abI
-bJP
-bLb
-bMi
-bZL
-bJP
-bLb
-bMi
-bZL
-bJP
-bLb
-bMi
-bZL
-bJP
-bLb
-bMi
-bZL
-bJP
+afj
 aht
-aaa
-amS
-hLk
-bZS
-bZj
-fDm
-pVp
-ltu
-qpI
+aph
+bVl
+kqA
+bWR
+kqA
+bVl
+pGj
+bWR
+pGj
+bVl
+pGj
+bWR
+bUz
+bVl
+pGj
+bWR
+kqA
+amV
+mXa
+hUX
+cYq
+mOH
+igl
+adC
+aYi
+aYi
+uEY
 bYw
 aaa
-brA
+gYo
 aaa
 aaa
 aaa
@@ -88798,26 +87861,26 @@ aaa
 aaa
 aaa
 aaa
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-ckK
-cju
-cju
-cju
-cju
-cju
-cju
-ckK
-cju
-cju
-cju
-cju
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88962,25 +88025,25 @@ aIk
 aFJ
 aGF
 aEj
-bct
+bcI
 aEj
 aEj
-aTo
-aTo
-aTo
-aTo
+bOz
+aTq
+xOt
+bXU
 aSk
 aYz
-aUw
-aUw
-lIy
-lIy
-aUw
-qXb
-udR
+xOt
+ntO
+baB
+baB
+bcS
+bbK
+bfH
+bfH
 dma
-dma
-dma
+bfH
 bfH
 cPy
 bCL
@@ -88992,51 +88055,51 @@ jOw
 bky
 bnY
 bpg
-bqr
+bcF
+mmV
 orz
 aaM
 afb
-bwa
-bwa
+bHY
 bzb
+vgg
 bAF
 bBL
 bCW
-bDW
-kmn
-bGn
-aRl
+bsn
+bFl
+bFl
 acy
 bWb
-bwm
+afj
+abI
 aht
-bJP
-bLc
-bMj
-bNo
-bJP
-bPg
-bPZ
-bQP
-bJP
-bSj
-bSW
-bTV
-bJP
-bVn
-bWe
-gYW
-bJP
-aht
-aht
-qFJ
+wTv
+abI
+aYB
+abI
+wTv
+abI
+aYB
+abI
+wTv
+abI
+aYB
+aaJ
+sLU
+aaJ
+xbT
+aaJ
+sCf
+qXu
+qXu
+bZi
+bZR
+caL
+qHB
 bYw
-iIF
-bYw
-sxd
-bYw
-bYw
-apR
+eml
+cdk
 bYw
 aht
 fon
@@ -89055,13 +88118,9 @@ aaa
 aaa
 aaa
 aaa
-cju
-cju
-cju
-ckK
-cju
-ckK
-ckK
+aaa
+aaa
+aaa
 cju
 cju
 cju
@@ -89069,13 +88128,17 @@ cju
 cju
 cju
 cju
-ckK
-ckK
-ckK
+aaa
+aaa
+aaa
+aaa
+aaa
 cju
-ckK
 cju
 cju
+cju
+cju
+aaa
 aaa
 aaa
 aaa
@@ -89222,20 +88285,20 @@ aEj
 bcI
 mgk
 aEj
-beH
-aRq
+une
+aTq
 tYu
-aTp
-aSk
+cCB
+xOt
 aVA
-aZD
-xKm
+aZo
+sql
 bgK
 baD
 sql
 jbo
-air
 bdJ
+gyj
 bdJ
 beM
 oOS
@@ -89245,58 +88308,61 @@ aEj
 asG
 iSi
 iSi
-acA
-acA
-acA
-acA
+hfZ
+hfZ
+hfZ
+hfZ
+bAR
 eYr
 bqs
-aaM
+aaQ
 afb
-bwa
-bwa
-wQQ
+bky
+bky
+bky
 wnJ
 bBM
 bCX
-aAA
-bFi
-bGo
-aRl
-acy
+sUP
+bFl
+bIa
+ozc
 lWy
-bwm
-aht
+afj
+abI
 bJP
-bLd
-bLe
-bLe
+bLb
+bMi
+bZL
 bJP
-bPh
-bQa
-bPh
+bLb
+bMi
+bZL
 bJP
-bSk
-bSX
-bSk
+bLb
+bMi
+bZL
 bJP
-bVo
-bWf
-bVo
+bLb
+bMi
+bZL
 bJP
-aht
-aaa
-pjO
-mRG
-bZU
-caO
-qux
-ybJ
-acT
-cdm
-cdm
 aht
 aaa
+amS
+hLk
+bZS
+bZj
+fDm
+pVp
+ltu
+qpI
+bYw
+aaa
+brA
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89314,22 +88380,19 @@ aaa
 aaa
 cju
 cju
-ckK
-cju
-ckK
-cju
-ckK
-ckK
 cju
 cju
 cju
-ckK
-cju
-ckK
 cju
 cju
 cju
-ckK
+cju
+cju
+cju
+cju
+cju
+cju
+cju
 cju
 cju
 cju
@@ -89480,22 +88543,22 @@ bcI
 aQk
 aEj
 rPW
-cCB
-cCB
+aTq
+iOi
 cCB
 xOt
 aWz
-cCB
+xOt
 gvi
-cCT
-cCT
+baB
+baB
 baE
 bbI
 bcE
 bfH
 bfH
-beN
-xae
+bfH
+bfH
 bgL
 bht
 aEj
@@ -89503,55 +88566,56 @@ biC
 biz
 iSi
 aam
-oov
-oov
+lqC
 aap
-bqt
+kQy
+bAR
+uwF
 bqs
 aaM
 afb
-bwa
-bwa
-buE
+bky
+bky
+bky
 vTN
 bFl
 bFl
-aAA
-bFj
-bGp
-aRl
+xGi
+bFl
+bHq
 afj
 ohe
-bwm
+afj
 aht
 bJP
-bLe
-bMk
-bLe
+bLc
+bMj
+bNo
 bJP
-bPh
-bQb
-bPh
+bPg
+bPZ
+bQP
 bJP
-bSk
-bSY
-bSk
+bSj
+bSW
+bTV
 bJP
-bVo
-bWg
-bVo
+bVn
+bWe
+gYW
 bJP
 aht
 aht
 qFJ
 bYw
-amS
+iIF
 bYw
-wxk
-eal
+sxd
 bYw
-aaa
-aaa
+bYw
+apR
+bYw
+aht
 fon
 aaa
 aaa
@@ -89567,22 +88631,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 cju
 cju
 cju
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
 cju
 cju
-cju
-ckK
-ckK
-ckK
-ckK
 cju
 cju
 cju
@@ -89593,6 +88648,14 @@ cju
 cju
 cju
 cju
+ckK
+cju
+cju
+cju
+cju
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89737,19 +88800,19 @@ bRm
 uAh
 aEj
 aXx
-aYx
-aZq
-aUs
-aSk
-aWz
+aTq
+xOt
 cCB
-aWB
+xOt
+aWz
+xOt
+cCB
 nxG
 baB
-baF
+bcL
 bbK
-bcF
-bfH
+bcE
+lTB
 als
 bfH
 lTB
@@ -89760,56 +88823,59 @@ aFi
 oEX
 iSi
 aau
-aaC
-aaF
+bGK
+ptK
 aaG
-aaH
-aaI
-aaI
+bAR
+bqt
+bqs
+aaM
 afb
-bwa
-bwa
-aWu
+bky
+bky
+bFh
 wnJ
 bBO
-sWM
-aAA
-bFk
-bGq
-aRl
-acy
+bFl
+bUr
+bFl
+bFl
+ama
 thT
-bwm
-abI
+bHy
+aht
 bJP
+bLd
+bLe
+bLe
 bJP
+bPh
+bQa
+bPh
 bJP
+bSk
+bSX
+bSk
 bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
+bVo
+bWf
+bVo
 bJP
 aht
 aaa
-aaa
+pjO
+mRG
+bZU
+caO
+qux
+ybJ
+acT
+cdm
+cdm
 aht
-abI
-bYw
-bYw
-bYw
-bYw
 aaa
 aaa
-fon
+aaa
 aaa
 aaa
 aaa
@@ -89828,21 +88894,7 @@ cju
 cju
 cju
 ckK
-ckK
-ckK
-ckK
-ckK
 cju
-ckK
-cju
-ckK
-ckK
-cju
-ckK
-ckK
-cju
-ckK
-ckK
 ckK
 ckK
 cju
@@ -89852,7 +88904,18 @@ cju
 cju
 cju
 cju
+ckK
+ckK
+ckK
 cju
+ckK
+cju
+cju
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89994,79 +89057,82 @@ bcI
 bcI
 glM
 aTq
-lqC
-aTq
-aTq
+aPd
+aWB
+pIa
 ebw
 aPd
-cCB
+xOt
 aXy
-cCT
-cCT
+baB
+baB
 baF
 bbK
 bcG
-bdM
+bfH
 jtf
 bfH
-efJ
+bfH
 pXH
 bhv
 aEj
 aEj
 asG
 iSi
-aaw
-aar
-oov
 aas
+xts
+ptK
+oMH
+bJa
 bqt
 bqs
 aaM
 afb
-bwa
-bwa
+bky
 bGs
+cec
 bAF
 bBP
-bCW
-bDX
-oje
-bJE
-aRl
-acy
+bKY
+bUr
+bFl
+bFl
+bzh
 bvo
-bwm
-abI
+bHy
 aht
-abI
+bJP
+bLe
+bMk
+bLe
+bJP
+bPh
+bQb
+bPh
+bJP
+bSk
+bSY
+bSk
+bJP
+bVo
+bWg
+bVo
+bJP
 aht
-abI
 aht
-aht
-aht
-aht
-aht
-abI
-aht
-aht
-aht
-abI
-aht
-aht
-aht
-aht
-aht
-abI
+qFJ
+bYw
+amS
+bYw
+wxk
+eal
+bYw
 aaa
 aaa
-abI
-aaa
-aaa
-aht
 fon
-fon
-fon
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90083,10 +89149,6 @@ aaa
 aaa
 cju
 cju
-cju
-ckK
-cju
-ckK
 ckK
 cju
 ckK
@@ -90099,20 +89161,21 @@ cju
 ckK
 cju
 ckK
-ckK
-ckK
 cju
 cju
-ckK
 cju
 ckK
 cju
 cju
 cju
-cju
-cju
-cju
-cju
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90251,78 +89314,79 @@ aEj
 aEj
 aEj
 bbG
-bbG
-bbG
-bbG
+xgP
+aUA
+bGg
 aUz
-iIB
-cCB
-aWB
-baB
+acF
+jWG
+aZD
+pLq
 fER
 bbG
 bbI
-bbI
-bbI
-bdI
-bfI
-bdI
-bbI
-bbI
+aXC
+kVS
+jsD
+bfH
+bfH
+bCB
+ndt
 aEj
 aGP
 asG
-aat
+iSi
 aay
 aav
-aax
+hmK
 aaz
+bAR
 aaB
-brH
-btp
+bqs
+aaM
 afb
-bwa
 teI
 uwh
+vbv
 bAF
 bBQ
-bDa
-bDX
-alB
-bXr
-aRl
-acy
-lWy
-aRl
+bNH
+bUr
+bFl
+bFl
+qpR
+uAx
 bHy
-bHy
-bHy
-bHy
-bHy
+abI
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+aht
 aaa
 aaa
-aaa
-acO
-aby
-aby
-aby
-aaa
-acO
-aby
-bzy
-gYo
-aaa
-gYo
-gYo
-gYo
+aht
+abI
+bYw
+bYw
+bYw
+bYw
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -90341,27 +89405,19 @@ aaa
 cju
 cju
 cju
-cju
-cju
-ckK
-cju
-ckK
 ckK
 ckK
 ckK
 cju
 ckK
+ckK
 cju
-ckK
-ckK
-ckK
-ckK
-clF
 cju
 cju
 ckK
 ckK
-cju
+ckK
+ckK
 cju
 cju
 cju
@@ -90371,6 +89427,13 @@ cju
 cju
 cju
 cju
+cju
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90504,58 +89567,83 @@ gYL
 gJY
 bcI
 aEj
-aMw
+oRX
 aPi
-aXC
-fDz
+oRX
+baC
 aTv
-aTv
-iUV
-cCB
+baC
+nJi
+eZj
 vrX
 cCB
-aXA
+cCB
 hvF
 ehK
 bbG
 aaa
-aaa
-aaa
+bbI
+bbI
 bdI
 bfJ
 bdI
-aaa
-aaa
+bbI
+bbI
 aEj
 cTq
 asG
 iSi
-vJR
-ptK
-rEd
-aap
+bOd
+bGK
+aeS
+aay
+bJa
 bqt
 bqs
 aaM
-afb
 elc
-bnO
+bod
 amp
+bod
 bAF
-fYY
 bDb
-bEc
-ajF
-bGt
-aRl
+rvH
+eHy
+bFl
+bFl
 bJR
-bwm
-aRl
-ccn
-bkv
-bNl
-bvS
-bHy
+xgv
+bXu
+abI
+aht
+abI
+aht
+abI
+aht
+aht
+aht
+aht
+aht
+abI
+aht
+aht
+aht
+abI
+aht
+aht
+aht
+aht
+aht
+abI
+aaa
+aaa
+abI
+aaa
+aaa
+aht
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -90571,38 +89659,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cju
-cju
-ckK
-cju
-cju
-cju
-cju
-ckK
-ckK
 cju
 cju
 cju
@@ -90610,27 +89666,34 @@ ckK
 ckK
 ckK
 ckK
+ckK
 cju
+ckK
+cju
+ckK
+ckK
+cju
+ckK
+ckK
+cju
+ckK
+ckK
 ckK
 ckK
 cju
 cju
 cju
-ckK
-cju
-cju
-cju
-ckK
-cju
-cju
-cju
-ckK
-clv
 cju
 cju
 cju
 cju
 cju
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90755,7 +89818,7 @@ atn
 atn
 atn
 aGJ
-aGJ
+rOT
 tpS
 aEj
 baP
@@ -90764,14 +89827,14 @@ aEj
 aMx
 aQp
 gZO
-cpz
-cpz
-tJB
+aOZ
+xdY
+baC
 iDV
 sQt
 iIB
 cCB
-aWB
+cCB
 gfC
 rCu
 bbG
@@ -90787,33 +89850,48 @@ aEj
 aEj
 asG
 iSi
-acA
-aap
-aap
-aap
-bqv
+hfZ
+bvS
+aeS
+bKU
+bAR
+bqt
 bqs
 aaM
-buD
-aMv
-bvT
-bvT
-aMv
-aZE
+gRu
+bez
+bEy
+ach
+bAF
 bDc
-cmA
 bGu
-aAF
-bBN
+bFp
+bGu
+xKm
 glf
-glf
-bXu
-vCA
-bOt
-bcr
-nwg
-bHy
-bHy
+iUX
+dWR
+iUX
+iUX
+iUX
+iUX
+aaa
+aaa
+aaa
+aaa
+acO
+aby
+aby
+aby
+aaa
+acO
+aby
+bzy
+gYo
+aaa
+gYo
+gYo
+gYo
 aaa
 aaa
 aaa
@@ -90838,38 +89916,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cju
-cju
-cju
-cju
-cju
 cju
 cju
 cju
 ckK
 cju
-cju
 ckK
 ckK
 cju
 ckK
+cju
 ckK
 ckK
-ckK
-ckK
-ckK
+cju
 cju
 cju
 ckK
@@ -90878,17 +89937,21 @@ ckK
 ckK
 ckK
 cju
-ckK
 cju
 ckK
+cju
 ckK
-ckK
-ckK
 cju
 cju
 cju
 cju
 cju
+cju
+cju
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91017,18 +90080,18 @@ aEj
 aEj
 baP
 aNQ
-aNT
+aEj
 aPh
 aQo
 aRg
 uhN
 nls
+baC
 cDa
-cDa
-aUA
+eZj
 iIB
 cCB
-aWB
+cCB
 gfC
 kRa
 aTy
@@ -91043,34 +90106,32 @@ aaa
 aaa
 aEj
 obj
-tim
+aLi
 bSe
+cme
+bHP
 aXB
-aXB
-aXB
+ayM
 bqw
 brH
 kGb
-buD
-bvT
-bFn
-nIr
-bvT
-uaP
+gRu
+bky
+bky
+byA
+bAF
 bEX
-bEd
-iBq
-bHz
-bIM
+bGu
+bFp
+bGu
+hdk
 bJQ
 xIx
 bIM
-bNp
+xIx
 bXC
 bcr
-bMm
-bHv
-bHy
+ccs
 aaa
 aaa
 aaa
@@ -91107,7 +90168,34 @@ aaa
 aaa
 aaa
 aaa
-cjv
+aaa
+aaa
+aaa
+aaa
+aaa
+cju
+cju
+cju
+cju
+cju
+ckK
+cju
+ckK
+ckK
+ckK
+ckK
+cju
+ckK
+cju
+ckK
+ckK
+ckK
+ckK
+clF
+cju
+cju
+ckK
+ckK
 cju
 cju
 cju
@@ -91117,35 +90205,10 @@ cju
 cju
 cju
 cju
-ckK
-ckK
 cju
-cju
-ckK
-ckK
-ckK
-cju
-cju
-cju
-cju
-ckK
-ckK
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
-clv
-cju
-cju
-cju
-cju
-cju
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91277,15 +90340,15 @@ aFi
 aEj
 aMy
 aSd
-bbO
+cJZ
 lSo
 bfC
-oMH
+baC
 nJi
 xAR
 aUw
 evg
-aWB
+cCB
 gfC
 kRa
 aTy
@@ -91299,39 +90362,33 @@ aaa
 aaa
 aaa
 aEj
-asG
-iSi
-nJI
-bky
-bky
-bzh
+bpq
+aFi
+hfZ
+iyy
+aUv
+feS
+bAR
 lAR
 bqs
-aaM
-buF
+aNL
 gRu
-sLD
+bky
 bKS
-bvT
-pFS
+spz
+bAF
 rxV
 eXo
-bez
-aTB
-aiw
-buw
-pgk
-aiw
+bFp
+bGu
+bGu
+bAE
+phx
+bFy
 dxo
 bcB
 noM
-fMe
-bRr
-bWQ
-bCV
-bCV
-cpA
-bFc
+ccs
 aaa
 aaa
 aaa
@@ -91362,33 +90419,28 @@ aaa
 aaa
 aaa
 aaa
-abI
-abI
-cjv
-cjv
-cjx
-cjx
-cjx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cju
 cju
 ckK
 cju
 cju
-ckK
-ckK
 cju
 cju
 ckK
 ckK
-ckK
 cju
 cju
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
+cju
 ckK
 ckK
 ckK
@@ -91399,11 +90451,22 @@ ckK
 cju
 cju
 cju
+ckK
+cju
 cju
 cju
 ckK
 cju
 cju
+cju
+ckK
+clv
+cju
+cju
+cju
+cju
+cju
+aaa
 aaa
 aaa
 aaa
@@ -91537,12 +90600,12 @@ lFi
 xbj
 aTa
 cvf
-gQa
-vQz
+baC
+nJi
 eZj
 gcq
 vsw
-ewd
+cCB
 aMf
 kRa
 aTy
@@ -91556,38 +90619,33 @@ aaa
 aaa
 aaa
 aEl
-asG
-iSi
-xPa
+bpq
+aEj
+hfZ
 akC
 bxK
-bzi
+bVW
+bJa
 bqx
 bqs
-aaM
-bxD
-bvT
+aRn
+mnE
 bEb
-aIe
-aMv
-mdP
+bky
+byv
+bAF
 bCg
+erW
+jvM
 bFp
-bGv
-bHA
-snm
+buw
 aaP
-aqr
-aiw
+bXD
+bGy
 bXD
 bOS
-blo
+bcr
 ccs
-tPZ
-afS
-acE
-bFs
-cpA
 aaa
 aaa
 aaa
@@ -91619,28 +90677,22 @@ aaa
 aaa
 aaa
 aaa
-abI
-ahi
-cjw
-cnp
-ckt
-cjx
-cjx
-cjx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cju
 cju
-ckK
-ckK
-ckK
-ckK
 cju
 cju
-ckK
-ckK
-ckK
 cju
-ckK
-ckK
+cju
+cju
+cju
 ckK
 cju
 cju
@@ -91652,10 +90704,21 @@ ckK
 ckK
 ckK
 ckK
-cju
 ckK
 cju
 cju
+ckK
+cju
+ckK
+ckK
+ckK
+cju
+ckK
+cju
+ckK
+ckK
+ckK
+ckK
 cju
 cju
 cju
@@ -91792,9 +90855,9 @@ aEj
 cCY
 cpz
 qIH
-jIM
+aVw
 dqY
-cDa
+baC
 jfl
 oMx
 cCB
@@ -91813,80 +90876,82 @@ aaa
 aaa
 aaa
 aEl
-asG
-iSi
-vxp
-bwc
-bxL
+bpq
+aFi
+hfZ
 bzj
+bxL
+bvm
+bJa
 tdp
 oDP
 bOV
-buH
-aMv
+bNW
+cqc
 bvT
-bvT
-aMv
-sci
-tgL
-eXo
-bGw
+aiw
+aiw
+aiw
+bTK
+bTK
 aTB
-aiw
-xyI
-aqr
-aiw
-anw
-aRp
-bCM
-aaV
-wEF
-bCV
-bCV
-bCV
-cdm
-aht
-aht
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-ahi
-cjx
-cjx
-cjx
-cjx
-cjx
-cjx
-cjx
+bTK
+bTK
+iUX
+bsH
+iUX
+iUX
+iUX
+iUX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cjv
+cju
+cju
+cju
+cju
 ckK
-ckK
+cju
+cju
+cju
+cju
 ckK
 ckK
 cju
@@ -91895,6 +90960,13 @@ ckK
 ckK
 ckK
 cju
+cju
+cju
+cju
+ckK
+ckK
+ckK
+ckK
 ckK
 cju
 ckK
@@ -91903,18 +90975,9 @@ ckK
 cju
 ckK
 ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
+clv
 cju
 cju
-cju
-cjx
 cju
 cju
 cju
@@ -92046,12 +91109,12 @@ aEj
 aJs
 aEj
 aEj
-cDa
+baC
 aPY
-cDa
-cDa
+baC
+baC
 bcV
-cDa
+baC
 dXq
 bbG
 aTy
@@ -92070,86 +91133,81 @@ aaa
 aaa
 aaa
 aEl
-asG
+bpq
+aEj
 iSi
 iSi
 iSi
-ayM
 iSi
 iSi
+bkF
 brR
 btt
 brR
-bAR
-aTs
+aiw
 bsp
-bAR
-bAR
-iUX
+aiw
+aiL
+aiw
 rCe
-qtA
-khk
-aiw
-aqr
-efU
-aiw
-bHy
-bHy
-bHy
-bHy
-bAu
-bJF
-rbg
+wFT
+bGx
+bnE
+brk
+bFK
+alB
+bGW
+bGW
+tuM
+aax
 aaa
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
 abI
-aaa
-aaa
-aaa
 abI
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
-ahi
+cjv
+cjv
 cjx
 cjx
 cjx
-ckL
-cjx
-clj
-cjx
-ckK
-ckK
-ckK
-ckK
+cju
 cju
 ckK
-ckK
-ckK
+cju
 cju
 ckK
 ckK
@@ -92157,25 +91215,30 @@ cju
 cju
 ckK
 ckK
-clv
-clv
-clv
+ckK
+cju
+cju
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
 ckK
 ckK
 ckK
 ckK
 cju
 ckK
-cju
-ckK
 ckK
 cju
-cjx
-cjV
-cnq
 cju
 cju
-aaa
+cju
+cju
+ckK
+cju
+cju
 aaa
 aaa
 aaa
@@ -92333,85 +91396,76 @@ vzP
 iWV
 wgM
 aFi
-iSi
+aFi
+bnj
 brT
 bxF
-wkZ
 bLq
-spz
-any
-ahp
-wFT
-iUX
-bHC
-bGx
-bHC
-aiw
-aqr
-pVr
 pgk
+aqr
+aiw
+aiw
+aiw
+bHC
+jCz
+bGx
+wFT
+wFT
+wFT
+bKG
+bGt
+ssc
+tAK
+aht
 aaa
 aaa
 aaa
-bHy
-bHy
-bHy
-bHy
-aht
-aht
-aht
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 ahi
+cjw
+cnp
+ckt
 cjx
 cjx
 cjx
-cjx
-cjx
-cjx
-cjx
-cju
-ckK
-ckK
-cju
-ckK
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
 cju
 cju
+ckK
+ckK
 ckK
 ckK
 cju
@@ -92419,20 +91473,29 @@ cju
 ckK
 ckK
 ckK
+cju
+ckK
+ckK
+ckK
+cju
+cju
+ckK
+ckK
+cju
 ckK
 ckK
 ckK
-cju
+ckK
+ckK
 cju
 ckK
 cju
 cju
 cju
-cjx
 cju
 cju
 cju
-aaa
+cju
 aaa
 aaa
 aaa
@@ -92590,87 +91653,74 @@ aEj
 wAI
 vzP
 vzP
-bqA
+vzP
+bGj
 brU
 roa
-buK
 dqw
 bGi
-pdW
-qMi
-nev
-iUX
-bFr
-bGy
-bHD
-aiw
 aqr
+aqr
+byg
 pgk
-pgk
-pgk
-aaa
-aaa
+bFr
+tJB
+bGx
+dQq
+wFT
+rjw
+bGW
+bGW
+bGW
+cdm
 aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
 abI
 ahi
-cjw
 cjx
 cjx
-ckt
 cjx
 cjx
-cju
-cju
+cjx
+cjx
+cjx
 ckK
-cju
-ckK
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
-cju
 ckK
 ckK
 ckK
@@ -92678,18 +91728,31 @@ cju
 cju
 ckK
 ckK
-cju
-cju
 ckK
 cju
 ckK
 cju
+ckK
+ckK
+ckK
+cju
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+cju
+ckK
+ckK
 cju
 cju
 cju
+cjx
 cju
 cju
-aaa
+cju
 aaa
 aaa
 aaa
@@ -92849,104 +91912,104 @@ iSi
 iSi
 iSi
 bkF
+bkF
 ume
 bkF
-hfZ
-iLl
-wTZ
-byg
-xgt
-iUX
-bPl
-bPl
-bPl
-arB
+aiw
+hKn
 aqr
-iGJ
-aUR
+aqr
 pgk
+bPl
+aLf
+bGx
+pDZ
+bpi
+bwu
+elL
+bDX
+aht
 aaa
+aht
 aaa
 aht
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abI
 aaa
 aaa
 aaa
 abI
-abI
-cjv
-cjv
-cjx
-cjx
-cjx
-cju
-ckK
-ckK
-cju
-ckK
-ckK
-ckK
-ckK
-cju
-ckK
-ckK
-ckK
-cju
-cju
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-ckK
-cju
-ckK
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
 aaa
+aaa
+aaa
+abI
+aaa
+aaa
+aaa
+abI
+aaa
+aaa
+aaa
+abI
+aaa
+aaa
+aaa
+abI
+aaa
+aaa
+aaa
+abI
+aaa
+aaa
+aaa
+abI
+aaa
+aaa
+aaa
+abI
+ahi
+cjx
+cjx
+cjx
+ckL
+cjx
+clj
+cjx
+ckK
+ckK
+ckK
+ckK
+cju
+ckK
+ckK
+ckK
+cju
+ckK
+ckK
+cju
+cju
+ckK
+ckK
+clv
+clv
+clv
+ckK
+ckK
+ckK
+ckK
+cju
+ckK
+cju
+ckK
+ckK
+cju
+cjx
+cjV
+cnq
+cju
+cju
 aaa
 aaa
 aaa
@@ -93108,85 +92171,72 @@ bqC
 tMs
 vMx
 xzp
-hfZ
-aUj
-blE
-urk
-iJb
-iUX
-bLf
-bLf
-bLf
-arB
-izF
+rlj
+aiw
+aiw
+pgk
+uzx
 pgk
 pgk
 pgk
-aaa
-aaa
+bLf
+pgk
+pgk
+pgk
+pgk
+pgk
 aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cjv
-cju
-cju
-cju
-cju
-cju
-cju
-ckK
-cju
-ckK
-cju
-cju
-ckK
-ckK
-ckK
-ckK
-ckK
-cju
+aht
+aht
+aht
+aht
+aht
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+abI
+ahi
+cjx
+cjx
+cjx
+cjx
+cjx
+cjx
+cjx
 cju
 ckK
 ckK
-ckK
-cju
-cju
 cju
 ckK
 ckK
@@ -93194,16 +92244,29 @@ ckK
 ckK
 cju
 ckK
+ckK
 cju
 cju
+ckK
+ckK
 cju
 cju
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
 cju
 cju
 ckK
 cju
 cju
-aaa
+cju
+cjx
+cju
+cju
+cju
 aaa
 aaa
 aaa
@@ -93365,23 +92428,23 @@ bzg
 brX
 csu
 ofN
-hfZ
+xQr
 pXg
-uAx
-cel
-aiL
-agB
+aiw
+aqr
+cDB
+aqr
 skj
-lfI
-rlj
+aqr
+cDB
 pgk
-aqD
+aUR
 pgk
 aht
 aht
 aht
+aaa
 aht
-aht
 aaa
 aaa
 aaa
@@ -93419,39 +92482,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-cju
-cju
-cju
-cju
-cju
-ckK
-ckK
-cju
-ckK
-cju
-cju
-ckK
-ckK
-cju
-ckK
-cju
-cju
-cju
-ckK
-cju
-ckK
-cju
+abI
+ahi
+cjw
+cjx
+cjx
+ckt
+cjx
+cjx
 cju
 cju
 ckK
 cju
 ckK
 ckK
+ckK
+ckK
+cju
+ckK
+ckK
+ckK
+cju
+ckK
+ckK
+cju
+ckK
+ckK
+ckK
 cju
 cju
+ckK
+ckK
 cju
 cju
+ckK
 cju
 ckK
 cju
@@ -93459,9 +92523,8 @@ cju
 cju
 cju
 cju
+cju
 aaa
-aaa
-abN
 aaa
 aaa
 aaa
@@ -93620,19 +92683,19 @@ thW
 aYg
 bqE
 brW
-btu
+btv
 xpr
-hfZ
-hfZ
-mzp
+buM
+amc
+aiw
 kPi
-azn
+cDB
 azn
 ctQ
 bFx
-gOV
+efU
 pgk
-aqr
+iGJ
 pgk
 aht
 aaa
@@ -93676,34 +92739,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cju
-cju
-cju
-cju
-cju
+abI
+abI
+cjv
+cjv
+cjx
+cjx
+cjx
 cju
 ckK
-ckK
-cju
-cju
 ckK
 cju
 ckK
 ckK
 ckK
-clv
-ckK
 ckK
 cju
-cju
-cju
+ckK
 ckK
 ckK
 cju
 cju
 ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+cju
+ckK
 cju
 cju
 cju
@@ -93712,12 +92781,6 @@ cju
 cju
 cju
 cju
-cju
-cju
-cju
-cju
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93876,17 +92939,17 @@ mQm
 ilD
 edJ
 bqF
-dQq
-qtf
+brW
+btv
 axj
 bSn
-hfZ
-cvV
+buK
+aiw
 pNf
-kkQ
+cDB
 rKL
 qvx
-bFy
+bFx
 bGB
 pgk
 lNW
@@ -93935,8 +92998,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cjv
 cju
+cju
+cju
+cju
+cju
+cju
+ckK
+cju
+ckK
 cju
 cju
 ckK
@@ -93944,12 +93015,9 @@ ckK
 ckK
 ckK
 ckK
-ckK
 cju
 cju
 ckK
-ckK
-cju
 ckK
 ckK
 cju
@@ -93957,11 +93025,8 @@ cju
 cju
 ckK
 ckK
-cju
-cju
 ckK
 ckK
-cju
 cju
 ckK
 cju
@@ -93970,11 +93035,9 @@ cju
 cju
 cju
 cju
+ckK
 cju
-aaa
-aaa
-aaa
-aaa
+cju
 aaa
 aaa
 aaa
@@ -94137,15 +93200,15 @@ nOY
 dgz
 jxl
 bTa
-hfZ
-aeV
+bnu
+aiw
 bQS
 izP
-aUj
-dfm
+gVu
+aqr
 llS
-lDw
-uzx
+aqr
+qEm
 cDB
 pgk
 aht
@@ -94192,9 +93255,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cju
 cju
 cju
 cju
@@ -94202,15 +93262,28 @@ cju
 cju
 ckK
 ckK
-cls
-ckK
-ckK
-cju
 cju
 ckK
 cju
 cju
 ckK
+ckK
+cju
+ckK
+cju
+cju
+cju
+ckK
+cju
+ckK
+cju
+cju
+cju
+ckK
+cju
+ckK
+ckK
+cju
 cju
 cju
 cju
@@ -94221,19 +93294,9 @@ cju
 cju
 cju
 cju
-cju
-cju
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abN
 aaa
 aaa
 aaa
@@ -94395,9 +93458,9 @@ qtF
 jwe
 xKc
 bkF
-bkF
-bkF
-bkF
+aiw
+aiw
+aiw
 aiw
 pgk
 pgk
@@ -94450,19 +93513,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cju
 cju
 cju
-ckK
 cju
-ckK
+cju
 cju
 ckK
 ckK
 cju
 cju
+ckK
+cju
+ckK
+ckK
+ckK
+clv
+ckK
+ckK
+cju
+cju
+cju
+ckK
+ckK
+cju
+cju
+ckK
 cju
 cju
 cju
@@ -94475,19 +93551,6 @@ cju
 cju
 cju
 cju
-cju
-cju
-cju
-cju
-cju
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94649,7 +93712,7 @@ oSc
 bsa
 gIG
 btv
-axk
+gvf
 bxM
 bzk
 bAH
@@ -94662,7 +93725,7 @@ pgk
 svN
 aqr
 uek
-izF
+aqr
 pgk
 qnT
 lJr
@@ -94708,10 +93771,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cju
+cju
+cju
+ckK
+ckK
+ckK
+ckK
+ckK
+ckK
+cju
+cju
+ckK
+ckK
+cju
+ckK
+ckK
+cju
+cju
+cju
+ckK
+ckK
+cju
+cju
+ckK
+ckK
+cju
+cju
+ckK
 cju
 cju
 cju
@@ -94719,30 +93806,6 @@ cju
 cju
 cju
 cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-cju
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94906,7 +93969,7 @@ bqH
 bsb
 pMI
 buJ
-sXV
+bnF
 bxN
 bzl
 blX
@@ -94917,9 +93980,9 @@ dMO
 aqr
 rxQ
 aqr
-izF
-izF
-izF
+aqr
+aqr
+aqr
 mES
 aqr
 aqr
@@ -94966,16 +94029,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
+cju
+cju
+cju
+cju
+cju
+ckK
+ckK
+cls
+ckK
+ckK
+cju
+cju
+ckK
+cju
+cju
+ckK
+cju
+cju
+cju
+cju
+ckK
 cju
 cju
 cju
@@ -94983,18 +94058,6 @@ cju
 cju
 cju
 cju
-cju
-cju
-cju
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -95162,8 +94225,8 @@ blX
 bqI
 igE
 gIG
-buM
-axk
+dxc
+gvf
 bxO
 bzm
 blX
@@ -95173,8 +94236,8 @@ aiw
 hTl
 bFC
 pgk
-izF
-izF
+aqr
+aqr
 pgk
 rah
 pgk
@@ -95224,34 +94287,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
+cju
+cju
+ckK
+cju
+ckK
+cju
+ckK
+ckK
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
 aaa
 aaa
 aaa
@@ -95420,7 +94483,7 @@ bqJ
 bsa
 gIG
 buL
-axk
+gvf
 bxM
 bzn
 yhB
@@ -95430,7 +94493,7 @@ aiw
 pgk
 pgk
 pgk
-izF
+aqr
 pgk
 pgk
 pgk
@@ -95484,28 +94547,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
 aaa
 aaa
 aaa
@@ -95676,8 +94739,8 @@ blX
 bqK
 bsd
 pMI
-buM
-sXV
+dxc
+bnF
 bxQ
 xxO
 blX
@@ -95687,8 +94750,8 @@ aiw
 qIO
 jXA
 pgk
-izF
-vpz
+aqr
+hXt
 pgk
 aht
 pgk
@@ -95748,16 +94811,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
+cju
 aaa
 aaa
 aaa
@@ -95933,8 +94996,8 @@ blX
 bqL
 bse
 gIG
-buM
-axk
+dxc
+gvf
 bxR
 bzp
 blX
@@ -96190,8 +95253,8 @@ ucn
 pkU
 bsa
 gIG
-buM
-axk
+dxc
+gvf
 bxM
 bzq
 yhB
@@ -96213,7 +95276,7 @@ aaa
 aed
 aaa
 aaa
-cFB
+aaa
 aaa
 aaa
 aaa
@@ -96448,7 +95511,7 @@ xoD
 smW
 pMI
 lXY
-sXV
+bnF
 bxS
 bzr
 blX
@@ -96470,7 +95533,7 @@ aby
 aby
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -97279,7 +96342,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abN
 aaa
 aaa
 aaa
@@ -97554,7 +96617,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abN
 aaa
 aaa
 aaa
@@ -97812,7 +96875,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+aaa
 aaa
 aaa
 aaa
@@ -98824,7 +97887,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32854,6 +32854,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -38246,6 +38247,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/lobby)
 "kRK" = (
@@ -42306,6 +42308,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -45295,6 +45298,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/lobby)
 "uEY" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4278,7 +4278,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "apR" = (
@@ -18173,6 +18173,11 @@
 	c_tag = "Medbay Psychology Office";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/button/door/directional/west{
+	id = "psychology";
+	name = "Privacy Shutters";
+	req_access = list("psychology")
+	},
 /turf/open/floor/carpet/purple,
 /area/station/medical/psychology)
 "bnP" = (
@@ -25546,6 +25551,10 @@
 /area/station/maintenance/department/engine)
 "bSs" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "psychology";
+	name = "Psychology Privacy"
+	},
 /turf/open/floor/plating,
 /area/station/medical/psychology)
 "bSt" = (
@@ -33443,8 +33452,8 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dOs" = (
@@ -37596,8 +37605,9 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "jTh" = (
@@ -38296,7 +38306,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "kVN" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38308,6 +38317,8 @@
 	name = "Chemistry";
 	req_access = list("pharmacy")
 	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kVO" = (
@@ -41728,6 +41739,7 @@
 	name = "Ordnance Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "pIy" = (
@@ -43061,8 +43073,9 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "rzp" = (
@@ -44293,7 +44306,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "tqC" = (

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -6,22 +6,22 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "ShuttleLoad"
+	id = "CargoLoad"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "f" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "ShuttleLoad"
+	id = "CargoLoad"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "g" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/west{
-	id = "cargoload";
-	name = "Loading Doors"
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "CargoLoad"
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
@@ -30,15 +30,13 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "k" = (
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "Supply Dock Loading Door"
+/obj/machinery/button/door/directional/west{
+	id = "cargounload";
+	name = "Loading Doors"
 	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "ShuttleLoad"
+/turf/open/floor/iron/chapel{
+	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "m" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50,17 +48,32 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
+"r" = (
+/obj/machinery/door/poddoor{
+	id = "cargoload";
+	name = "Supply Dock Loading Door"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "CargoLoad"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/supply)
 "s" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
+/obj/machinery/button/door/directional/west{
+	id = "cargoload";
+	name = "Loading Doors"
+	},
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
 /area/shuttle/supply)
 "t" = (
-/obj/machinery/button/door/directional/west{
-	id = "cargounload";
-	name = "Loading Doors"
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "CargoUnload"
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
@@ -71,16 +84,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "ShuttleUnload"
+	id = "CargoUnload"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "y" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "ShuttleUnload"
+	id = "CargoUnload"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "z" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -116,11 +129,11 @@
 "I" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "ShuttleLoad"
+	dir = 5;
+	id = "CargoLoad"
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "J" = (
 /obj/machinery/door/poddoor{
@@ -129,7 +142,7 @@
 	},
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "ShuttleUnload"
+	id = "CargoUnload"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
@@ -153,11 +166,11 @@
 "T" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "ShuttleUnload"
+	dir = 9;
+	id = "CargoUnload"
 	},
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "U" = (
 /turf/open/floor/iron/chapel,
@@ -170,15 +183,15 @@
 
 (1,1,1) = {"
 a
-k
 a
+r
 a
 a
 R
 a
 a
-a
 J
+a
 a
 B
 "}
@@ -190,7 +203,7 @@ s
 X
 w
 K
-X
+k
 t
 T
 a


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjust Pubby layout in half the departments to "improve" stuff or restore "good" lost features. Cargo, Sci, Med depts tweaked at large, Atmos tweaked, AI sat restored.

[image](https://cdn.discordapp.com/attachments/600918985130770432/1215729123033616384/StrongDMM-2024-03-08_13.32.51.png?ex=65fdcefa&is=65eb59fa&hm=0c6afe7f8aeaccf42a82b8a2da340a476b79dd8ebdd080170554dc1498272f76&)

tested lights, intercoms, cameras, disposals

## Why It's Good For The Game

because i said so

...

but really just been wanting to fix up some things i didn't do great last time i touched the map, and to restore some ancient gems like D&D room. as usual please PLEASE give me feedback if you don't like something, i'm a slut for mapping but also i'm kinda tired after working on this all week

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Pubby D&D room
fix: Pubby dept layouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
