### PR TITLE
AI sats and cube adjustments

### DIFF
--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -57,6 +57,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "aaU" = (
@@ -149,10 +150,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "adj" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -170,6 +171,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "adH" = (
@@ -260,12 +262,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "agj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "agG" = (
@@ -281,6 +278,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"agK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "agL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -439,15 +451,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "alQ" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "amc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -576,11 +585,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "apx" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/closet/secure_closet/cytology,
+/obj/item/storage/bag/xeno,
+/obj/item/storage/box/petridish,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "apZ" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Captain's Office"
@@ -642,6 +652,7 @@
 	name = "Bar Storage Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "arz" = (
@@ -658,11 +669,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "arJ" = (
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/machinery/monkey_recycler,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "arR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -694,6 +703,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
+"asf" = (
+/obj/machinery/byteforge,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "asu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -806,12 +819,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "avs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "avt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -894,6 +905,7 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/directional/east,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "awo" = (
@@ -976,7 +988,10 @@
 /area/space/nearstation)
 "aza" = (
 /obj/machinery/processor,
-/obj/effect/turf_decal/stripes/box,
+/obj/structure/table,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "aze" = (
@@ -984,6 +999,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"azg" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "azk" = (
 /obj/machinery/requests_console{
 	department = "Head of Security's Desk";
@@ -1005,7 +1026,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "azy" = (
-/obj/structure/cable,
 /obj/structure/chair{
 	dir = 8
 	},
@@ -1111,14 +1131,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "aDD" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "aDK" = (
 /obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "aEa" = (
@@ -1173,16 +1193,17 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "aFF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "aFO" = (
@@ -1265,12 +1286,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aGU" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/cargo/miningdock"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "aGV" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
@@ -1419,16 +1445,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "aLO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "aLP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -1480,8 +1500,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "aNp" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "aNZ" = (
@@ -1621,12 +1641,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aSb" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/effect/spawner/atmos_canister/anesthetic_mix,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "aSf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -1809,6 +1831,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aXU" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "aYu" = (
@@ -1964,7 +1987,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "baT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -1974,7 +1997,7 @@
 	name = "Security External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "bck" = (
@@ -2043,6 +2066,13 @@
 /obj/effect/spawner/atmos_canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
+"bdD" = (
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #4";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bdN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Mix"
@@ -2168,9 +2198,6 @@
 "biK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -2400,6 +2427,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"bpi" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bpq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2434,6 +2473,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "bqK" = (
@@ -2628,8 +2668,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
 "bxy" = (
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/machinery/computer/monitor,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "bxC" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -2688,7 +2729,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Brig"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "byC" = (
@@ -2781,12 +2822,9 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
 "bBM" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/pointy/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bCt" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2864,12 +2902,16 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "bDt" = (
-/obj/structure/chair{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "bDB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -2911,6 +2953,10 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
+"bEe" = (
+/obj/machinery/module_duplicator,
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "bEC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2944,21 +2990,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bEV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/engineering/break_room)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/trash/can,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "bEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -3034,9 +3069,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "bGg" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/left/directional/north{
@@ -3051,12 +3085,12 @@
 /area/station/ai_monitored/command/storage/eva)
 "bGr" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/landmark/start/research_director,
 /obj/structure/chair/office/light{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
@@ -3068,6 +3102,7 @@
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bGM" = (
@@ -3082,14 +3117,8 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "bGZ" = (
-/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "bHk" = (
@@ -3116,16 +3145,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/window/left/directional/west{
+/obj/machinery/door/window/right/directional/west{
 	name = "Brig Infirmary"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/brig)
 "bHX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "bHY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -3304,6 +3338,7 @@
 	id_tag = "commissarydoor";
 	name = "Vacant Commissary"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "bND" = (
@@ -3330,10 +3365,8 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "bOe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bOq" = (
@@ -3398,7 +3431,7 @@
 "bPI" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/area/station/maintenance/port)
 "bQg" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
@@ -3496,6 +3529,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "bSg" = (
@@ -3513,16 +3547,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bSj" = (
-/obj/machinery/iv_drip,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/area/station/science/research)
 "bSn" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -3646,9 +3683,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bVL" = (
-/obj/structure/flora/rock,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen)
 "bVX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -3699,12 +3740,8 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bXc" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/robotics/mechbay"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bXj" = (
 /turf/open/space/basic,
 /area/space)
@@ -3766,40 +3803,24 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "bYT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/window/left/directional/west{
-	name = "Monkey Pen";
-	req_access = list("virology")
-	},
-/obj/machinery/door/window/left/directional/east{
-	name = "Monkey Pen";
-	req_access = list("virology")
-	},
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/sign/poster/official/safety_report/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "bZn" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
 	},
-/obj/effect/turf_decal/stripes/box,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Front Desk";
 	network = list("ss13","engine")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "bZp" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "cag" = (
 /obj/structure/window/spawner/directional/north,
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/burnchamber)
@@ -3861,6 +3882,20 @@
 /obj/machinery/air_sensor/air_tank,
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
+"cbM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ccj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -3886,12 +3921,10 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit)
 "cdl" = (
-/obj/machinery/netpod,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "cdE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3904,9 +3937,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cdF" = (
-/obj/item/trash/can,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
+/obj/structure/chair/comfy/black,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "cdI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3940,9 +3973,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cfs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -4014,24 +4044,21 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ciC" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/tools"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "ciD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "ciG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -4060,10 +4087,13 @@
 "ckk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "ckE" = (
@@ -4104,6 +4134,12 @@
 	dir = 1;
 	network = list("mine","auxbase","vault","qm")
 	},
+/obj/machinery/requests_console/directional/south{
+	department = "Quartermaster's Desk";
+	name = "Quartermaster RC"
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/announcement,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "ckZ" = (
@@ -4170,6 +4206,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "cmF" = (
@@ -4407,14 +4444,14 @@
 /area/station/engineering/main)
 "csj" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "csL" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/computer/atmos_control/ordnancemix{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "csY" = (
@@ -4502,11 +4539,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cvW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/machinery/processor/slime,
-/obj/effect/turf_decal/stripes/box,
+/obj/structure/table,
+/obj/item/mmi,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/ecto_sniffer{
+	pixel_x = -6;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/science/robotics/lab)
 "cwj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -4519,6 +4560,8 @@
 /area/station/engineering/supermatter/room)
 "cwm" = (
 /obj/structure/table,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "cwL" = (
@@ -4544,17 +4587,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cxy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/bombcloset,
+/obj/machinery/computer/exoscanner_control,
 /turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/area/station/cargo/drone_bay)
 "cxM" = (
-/obj/machinery/byteforge,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/south,
-/turf/open/floor/plating,
-/area/station/cargo/bitrunning/den)
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "cxO" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Bee Containment";
@@ -4790,6 +4831,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
 /obj/item/pai_card,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "cGy" = (
@@ -4799,13 +4841,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/north{
-	network = list("ss13","rd")
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "cHh" = (
@@ -4983,6 +5022,9 @@
 	pixel_x = -11;
 	pixel_y = -23
 	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "cLY" = (
@@ -5117,15 +5159,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "cQc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "cQk" = (
@@ -5345,7 +5385,7 @@
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/book/manual/wiki/surgery,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "cWV" = (
 /obj/structure/chair{
 	dir = 1
@@ -5397,15 +5437,17 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cYK" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/computer/security/mining{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	department = "Mining";
 	pixel_y = -30
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
@@ -5430,26 +5472,24 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"cZx" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "cZI" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "cZQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/computer/mechpad{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "dam" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/table,
 /obj/structure/cable,
-/obj/machinery/fax{
-	fax_name = "Cargo Office";
-	name = "Cargo Office Fax Machine";
-	pixel_y = 7
-	},
+/obj/machinery/photocopier,
+/obj/item/clipboard,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "dav" = (
@@ -5705,9 +5745,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "div" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/medical/surgery/aft)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "diC" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
@@ -5721,11 +5764,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "diW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "dja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5898,16 +5938,23 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "dnw" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/chapel"
+/obj/machinery/door/airlock/mining{
+	name = "Drone Bay"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/old{
+	dir = 8
+	},
+/area/station/cargo/drone_bay)
 "dnJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "dnS" = (
@@ -5922,15 +5969,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"doe" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/bouldertech/refinery/smelter,
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "mining"
+"doc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
+/area/station/service/theater)
+"doe" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "dog" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -5947,7 +6000,8 @@
 "dop" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "dou" = (
 /obj/machinery/door/firedoor,
@@ -5999,7 +6053,7 @@
 	name = "Port Emergency Storage"
 	},
 /turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/area/station/maintenance/port)
 "dpw" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -6007,24 +6061,27 @@
 /turf/open/floor/carpet/green,
 /area/station/service/theater)
 "dqd" = (
-/obj/machinery/quantum_server,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "dqe" = (
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
 "dqh" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/mob/living/simple_animal/bot/secbot/pingsky,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "dqk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "dqs" = (
@@ -6120,6 +6177,21 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
+"dtM" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "dtQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -6174,12 +6246,12 @@
 /area/station/hallway/secondary/entry)
 "dvg" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/fax{
 	fax_name = "Chief Engineer's Office";
 	name = "Chief Engineer's Fax Machine"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -6272,9 +6344,15 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "dyc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "dye" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6316,9 +6394,6 @@
 "dzD" = (
 /obj/machinery/computer/station_alert{
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/machinery/incident_display/delam/directional/south,
 /turf/open/floor/iron/showroomfloor,
@@ -6437,6 +6512,19 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"dDo" = (
+/obj/structure/table/glass,
+/obj/item/biopsy_tool{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/book/manual/wiki/cytology{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "dEn" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
@@ -6503,10 +6591,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -6530,16 +6618,23 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "dFO" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper{
-	pixel_y = 5
+/obj/machinery/turretid{
+	control_area = "/area/station/ai_monitored/turret_protected/ai";
+	name = "AI Chamber turret control";
+	pixel_x = 5;
+	pixel_y = -24
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 4
+/obj/machinery/newscaster/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat AI Chamber Core";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "dFR" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -6613,6 +6708,18 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dHw" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "dHz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/east{
@@ -6685,11 +6792,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dIr" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "dIs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6841,11 +6949,12 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "dNM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/camera/motion/directional/north{
+	network = list("minisat");
+	c_tag = "MiniSat External Aft"
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/open/space/basic,
+/area/space)
 "dNP" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker/impressa,
@@ -6952,6 +7061,7 @@
 "dPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "dPx" = (
@@ -6968,10 +7078,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "dPQ" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/structure/chair,
+/obj/effect/turf_decal/siding/white/end{
 	dir = 4
 	},
-/obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "dPY" = (
@@ -7021,9 +7131,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "dQN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
@@ -7062,6 +7171,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "dSi" = (
@@ -7087,18 +7197,17 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "dTk" = (
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "dTA" = (
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "dTM" = (
-/obj/structure/disposalpipe/sorting/mail{
-	name = "experimenter sorting disposal pipe";
-	sortType = 24
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "dTQ" = (
@@ -7428,17 +7537,17 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "edL" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/status_display/ai/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "edO" = (
 /obj/structure/table,
 /obj/item/storage/box/rxglasses{
@@ -7510,15 +7619,16 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "eeI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/atmos_canister/plasma,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
-"eeQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/science/server)
+"eeQ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/atmos_canister/oxygen,
 /turf/open/floor/iron/dark,
@@ -7645,10 +7755,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/sign/warning/no_smoking/directional/north,
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "egY" = (
@@ -7656,10 +7767,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ehm" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/cargo/warehouse"
-	},
 /obj/structure/cable,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "ehw" = (
@@ -7894,9 +8003,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"emp" = (
+/obj/machinery/digital_clock/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "emG" = (
 /obj/effect/spawner/random/maintenance/three,
-/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "emV" = (
@@ -7914,17 +8026,18 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/start/scientist,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "enz" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/machinery/cryo_cell,
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 4
 	},
-/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "enF" = (
@@ -7980,6 +8093,14 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"eoM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "eoU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7989,19 +8110,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "epd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
-/obj/machinery/door/airlock/mining/glass{
-	id_tag = "innercargo";
-	name = "Bitrunning Club"
-	},
-/turf/open/floor/plating,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "epo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8041,7 +8156,10 @@
 /area/station/maintenance/starboard/lesser)
 "eqz" = (
 /obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/starboard)
 "eqU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -8061,7 +8179,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
 /obj/item/universal_scanner{
 	pixel_x = -2
 	},
@@ -8071,15 +8188,15 @@
 	},
 /obj/item/universal_scanner,
 /obj/structure/rack,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","qm")
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "erU" = (
-/obj/docking_port/stationary/random{
-	name = "lavaland";
-	shuttle_id = "pod_4_lavaland"
-	},
+/obj/structure/transit_tube,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "eso" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/light/directional/west,
@@ -8135,11 +8252,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "etC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "etD" = (
 /obj/structure/table/glass,
@@ -8151,22 +8265,19 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "etJ" = (
-/obj/structure/flora/bush/sunny/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "eud" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "euv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -8271,9 +8382,7 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "exk" = (
@@ -8363,6 +8472,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"ezj" = (
+/obj/item/radio/intercom/directional/east{
+	broadcasting = 1;
+	listening = 0;
+	frequency = 1447
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "ezk" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lantern{
@@ -8425,17 +8544,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eBw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/obj/machinery/light/directional/north,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "eBE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -8540,9 +8651,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /mob/living/basic/bot/medbot,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -8603,22 +8711,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eGP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/research{
-	name = "Testing Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "experimentation-lab"
+/obj/structure/table,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/button/door{
+	id = "testlab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = 2;
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
@@ -8661,9 +8761,6 @@
 "eIG" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "eJb" = (
@@ -8811,12 +8908,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "eMI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_green{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -8851,6 +8948,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "eOd" = (
@@ -8887,16 +8985,13 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "ePG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
 	name = "Biohazard Containment Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/sign/warning/secure_area/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ePS" = (
 /turf/open/floor/plating,
@@ -8910,10 +9005,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eQf" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/extinguisher,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/window/left/directional/west{
+	name = "Containment Pen #5";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "eQl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -8970,6 +9066,7 @@
 	name = "Genetics Lab Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "eRi" = (
@@ -8998,9 +9095,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "eSD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -9077,11 +9171,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "eTN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
+/obj/effect/landmark/navigate_destination/minisat_access_ai,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/lesser)
 "eTU" = (
 /turf/closed/wall,
 /area/station/commons/toilet)
@@ -9095,6 +9187,7 @@
 	name = "Quartermaster Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "eUT" = (
@@ -9111,10 +9204,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "eVg" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/camera/autoname/directional/east{
 	network = list("ss13","qm")
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
@@ -9351,9 +9446,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "fcn" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "fcx" = (
@@ -9425,6 +9522,7 @@
 	pixel_y = -32
 	},
 /obj/structure/displaycase/trophy,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "feb" = (
@@ -9518,6 +9616,11 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/central)
+"fgc" = (
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "fgi" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -9536,17 +9639,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fgC" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair/office{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
@@ -9607,7 +9701,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "fin" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance"
@@ -9626,11 +9720,15 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/commons/dorms)
 "fiE" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "fiJ" = (
 /turf/open/floor/wood,
@@ -9821,7 +9919,10 @@
 /area/station/medical/chemistry)
 "fpx" = (
 /obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "fpz" = (
 /obj/structure/closet/emcloset,
@@ -9918,14 +10019,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "fss" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fsQ" = (
 /turf/open/floor/carpet/red,
 /area/station/service/lawoffice)
@@ -9946,11 +10044,7 @@
 /turf/open/floor/iron,
 /area/station/security)
 "ftR" = (
-/obj/structure/rack,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/item/integrated_circuit/loaded/hello_world,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/science/circuits)
 "fub" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9989,11 +10083,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "fvt" = (
-/mob/living/carbon/human/species/monkey{
-	name = "Squared"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fvE" = (
 /obj/machinery/power/apc/auto_name/directional/east{
 	areastring = "/area/station/security/prison"
@@ -10024,7 +10119,6 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "fwa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -10115,9 +10209,11 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "fxq" = (
-/obj/structure/sign/warning/pods/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air Out"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "fxt" = (
 /turf/open/floor/circuit,
 /area/station/science/robotics/mechbay)
@@ -10213,11 +10309,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fzf" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fzg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10232,6 +10332,7 @@
 /area/station/maintenance/aft)
 "fzy" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
 "fAd" = (
@@ -10292,6 +10393,7 @@
 /obj/effect/landmark/navigate_destination{
 	location = "Psychology Office"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "fCd" = (
@@ -10300,6 +10402,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "fCo" = (
@@ -10470,6 +10574,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fJu" = (
@@ -10505,6 +10610,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "fKd" = (
@@ -10568,9 +10676,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "fMQ" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/command/gateway"
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -10583,16 +10688,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fMY" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/closed/wall,
+/area/station/science/cytology)
 "fNg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -10608,7 +10705,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "fNm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10662,6 +10759,8 @@
 /area/station/maintenance/port/aft)
 "fOv" = (
 /obj/machinery/camera/autoname/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "fOF" = (
@@ -10789,18 +10888,19 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central)
 "fRq" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fRz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10826,6 +10926,7 @@
 	name = "Detective Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fSa" = (
@@ -10877,12 +10978,11 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain)
 "fUa" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 4
 	},
-/obj/structure/cable,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "fUe" = (
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
@@ -10907,12 +11007,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "fVL" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/mob/living/carbon/human/species/monkey{
-	name = "4D"
-	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/netpod,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "fVN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/garbage,
@@ -10922,15 +11020,13 @@
 /turf/closed/wall,
 /area/station/maintenance/aft)
 "fVU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "fWf" = (
@@ -10963,13 +11059,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "fWv" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "fWE" = (
@@ -10980,12 +11076,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "fWT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "fWV" = (
 /obj/machinery/door/airlock{
@@ -11009,13 +11106,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "fXg" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/chapel/office"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fXi" = (
 /turf/closed/wall,
 /area/station/cargo/miningdock)
@@ -11041,15 +11139,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/sink/directional/east,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "fXx" = (
@@ -11057,12 +11153,9 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "fXW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light/small/dim/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/area/station/commons/vacant_room/commissary)
 "fXY" = (
 /obj/machinery/computer/atmos_control/nitrous_tank{
 	dir = 4
@@ -11159,13 +11252,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "gbw" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/medical/pharmacy"
-	},
-/obj/structure/cable,
 /obj/structure/table,
 /obj/effect/landmark/start/hangover,
 /obj/effect/decal/cleanable/cobweb,
@@ -11224,14 +11315,9 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "gdf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/virology{
-	name = "Break Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "gdg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -11254,6 +11340,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
+"gdy" = (
+/obj/machinery/vending/cola/black,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "gdG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -11263,15 +11353,16 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "gdH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/security/detectives_office"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "gdO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/air_sensor/incinerator_tank,
@@ -11280,6 +11371,10 @@
 "gdX" = (
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"gea" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "get" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -11323,13 +11418,19 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"ggq" = (
-/obj/structure/disposalpipe/segment{
+"ggk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
+"ggq" = (
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat Chamber Starboard";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "ggx" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -11343,6 +11444,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/hand_labeler,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ggG" = (
@@ -11411,6 +11513,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "ghV" = (
@@ -11554,7 +11657,7 @@
 /area/station/security/execution/transfer)
 "gmc" = (
 /obj/machinery/component_printer,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/science/circuits)
 "gmn" = (
 /obj/effect/turf_decal/tile/red,
@@ -11636,6 +11739,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "gpt" = (
@@ -11711,16 +11815,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "gqV" = (
-/obj/structure/closet,
-/obj/item/circuitboard/machine/exoscanner,
-/obj/item/circuitboard/machine/exoscanner,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/item/fuel_pellet,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "gqW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
@@ -11813,10 +11911,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -11830,14 +11928,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/rd)
 "gsZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -11845,6 +11941,15 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/turf_decal/bot,
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Cargo Office";
+	name = "Cargo Office Fax Machine";
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "gta" = (
@@ -11939,15 +12044,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gvO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/science/server)
+/area/station/maintenance/port/aft)
 "gwk" = (
 /obj/structure/table,
 /obj/item/radio/off{
@@ -12002,14 +12103,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "gwU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/turf/open/floor/plating,
+/area/station/science/server)
 "gwZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -12081,7 +12180,10 @@
 /area/station/maintenance/port/aft)
 "gyi" = (
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/starboard)
 "gyo" = (
 /obj/machinery/door/window/left/directional/south{
@@ -12228,9 +12330,6 @@
 	id = "toxinsdriver";
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/item/computer_disk,
 /obj/item/computer_disk,
 /obj/item/computer_disk,
@@ -12268,10 +12367,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "gDk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/computer/piratepad_control/civilian{
-	dir = 4
-	},
+/obj/effect/turf_decal/siding/brown,
+/obj/machinery/piratepad/civilian,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "gDC" = (
@@ -12279,6 +12376,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gDD" = (
@@ -12308,6 +12406,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "gDM" = (
@@ -12325,11 +12424,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_green{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -12368,11 +12467,8 @@
 /turf/closed/wall,
 /area/station/commons/vacant_room/office)
 "gFF" = (
-/obj/machinery/door/window/left/directional/west{
-	name = "Containment Pen #2";
-	req_access = list("xenobiology")
-	},
-/turf/open/floor/engine,
+/obj/machinery/processor/slime,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "gGh" = (
 /obj/effect/turf_decal/stripes/line,
@@ -12422,6 +12518,10 @@
 /obj/item/storage/box/firingpins,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"gHu" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "gHB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -12475,6 +12575,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "gIS" = (
@@ -12525,6 +12626,7 @@
 "gKy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "gKK" = (
@@ -12702,11 +12804,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "gRc" = (
-/obj/item/toy/sprayoncan,
-/obj/item/toy/xmas_cracker,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "gRz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12717,7 +12818,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gRC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
 	},
 /turf/open/floor/circuit,
@@ -12789,6 +12890,7 @@
 	name = "Kitchen Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gSO" = (
@@ -12814,14 +12916,21 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gTB" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/machinery/door/airlock/research/glass{
+	name = "Cytology Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "gTK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -12855,17 +12964,14 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain)
 "gUI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "gUS" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -12918,7 +13024,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/dark_green{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -12932,7 +13038,6 @@
 /area/station/science/research)
 "gWm" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gWn" = (
@@ -13025,8 +13130,8 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "gZU" = (
-/obj/effect/gibspawner/confetti,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hae" = (
@@ -13133,12 +13238,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "hdi" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/dorms"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "hdR" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -13286,6 +13391,7 @@
 "hhN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/cyan,
 /area/station/service/library)
 "hid" = (
@@ -13354,6 +13460,16 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"hjX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "hke" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -13474,10 +13590,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "hnW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/landmark/start/shaft_miner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hnY" = (
@@ -13506,6 +13620,7 @@
 	pixel_x = 25;
 	pixel_y = -26
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "hol" = (
@@ -13598,6 +13713,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
 "hqu" = (
@@ -13643,9 +13760,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "hrl" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/robotics/lab)
 "hrJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13702,17 +13819,21 @@
 /obj/effect/spawner/atmos_canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"hta" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+"hsV" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
+"hta" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
 	name = "Biohazard Containment Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/sign/warning/explosives/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "htf" = (
 /obj/structure/dresser,
@@ -13762,9 +13883,6 @@
 	},
 /obj/item/tank/jetpack/carbondioxide{
 	pixel_x = -7
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -13855,8 +13973,18 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "hvG" = (
-/turf/closed/wall,
-/area/station/commons/storage/emergency/port)
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/glasses/science{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "hvI" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -13872,8 +14000,10 @@
 /area/space/nearstation)
 "hvQ" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hwk" = (
@@ -13947,9 +14077,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hyu" = (
@@ -14008,9 +14135,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/wrench/medical,
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
@@ -14031,7 +14155,7 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "hzw" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
@@ -14053,16 +14177,11 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "hzV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/command{
-	name = "Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/science/server)
+/turf/open/floor/wood,
+/area/station/service/library)
 "hAA" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
@@ -14081,6 +14200,10 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"hAN" = (
+/obj/machinery/vending/cola/starkist,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "hAP" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
@@ -14095,10 +14218,10 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "hBh" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/showroomfloor,
-/area/station/cargo/sorting)
+/area/station/hallway/primary/starboard)
 "hBq" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/firealarm/directional/north,
@@ -14204,7 +14327,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/area/station/maintenance/port)
 "hFN" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -14259,9 +14382,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -14309,9 +14429,6 @@
 /area/station/engineering/atmos)
 "hHD" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/commons/storage/emergency/port"
-	},
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -14322,9 +14439,6 @@
 	pixel_y = 10
 	},
 /obj/item/clothing/shoes/magboots,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -14333,19 +14447,19 @@
 /turf/closed/wall,
 /area/station/service/chapel)
 "hIr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "hJj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/atmos_canister/air,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hJp" = (
@@ -14517,6 +14631,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "hOy" = (
@@ -14581,10 +14697,19 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"hRq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+"hQp" = (
+/obj/machinery/light/directional/west,
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
+"hQI" = (
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat Chamber Port";
+	network = list("minisat")
 	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
+"hRq" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/turf_decal/tile/holiday/random,
 /obj/effect/turf_decal/tile/holiday/random{
@@ -14608,10 +14733,13 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "hRR" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/docking_port/stationary/random{
+	name = "lavaland";
+	shuttle_id = "pod_4_lavaland";
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "hSn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -14667,6 +14795,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "hTf" = (
@@ -14709,9 +14838,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/burnchamber)
 "hVd" = (
@@ -14807,8 +14933,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "hXb" = (
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "hXj" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -14891,9 +15021,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hZr" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/table,
+/obj/item/multitool/circuit{
+	pixel_x = 7
+	},
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit{
+	pixel_x = -8
+	},
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "hZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -15006,6 +15143,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "ibC" = (
@@ -15198,10 +15336,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "iiG" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -15209,7 +15343,10 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "ijs" = (
 /obj/effect/turf_decal/bot,
@@ -15264,9 +15401,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "ilN" = (
-/obj/machinery/computer/exoscanner_control,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 16
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "ilO" = (
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/dark,
@@ -15301,10 +15446,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/turf_decal/siding/brown{
 	dir = 6
 	},
-/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "inx" = (
@@ -15319,8 +15464,10 @@
 "inE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "inT" = (
 /obj/structure/cable,
@@ -15373,15 +15520,18 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ipw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/area/station/science/xenobiology)
 "ipJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -15409,6 +15559,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/mob/living/basic/mothroach{
+	desc = "That's mining's pet mothroach Aemilia. Affectionately known as the mini Darkheart they're quite sweet, offering weary miners reassurance after long days of carving hardened basalt and running from megafauna.";
+	name = "Aemilia"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "iqn" = (
@@ -15431,9 +15585,11 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "iqM" = (
-/obj/machinery/exodrone_launcher,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/effect/landmark/start/cyborg,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "iqX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -15464,11 +15620,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "ism" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/requests_console{
+	department = "Science";
+	name = "Science Requests Console";
+	pixel_x = 30
 	},
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "isz" = (
@@ -15643,15 +15802,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "iyc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/machinery/computer/station_alert,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "iym" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -15693,6 +15846,12 @@
 "izI" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
+"iAn" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "iAw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -15802,8 +15961,12 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "iDb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "iDk" = (
 /obj/structure/window/spawner/directional/west{
@@ -15818,12 +15981,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "iDn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/closet/firecloset,
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "iDu" = (
@@ -16019,6 +16182,7 @@
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "iJk" = (
@@ -16037,9 +16201,25 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "iJE" = (
-/obj/item/gun/ballistic/revolver/russian,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom"
+	},
+/obj/item/radio/intercom/directional/north{
+	frequency = 1447;
+	name = "Private Channel";
+	freerange = 1
+	},
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "iJH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -16091,11 +16271,10 @@
 /turf/open/floor/iron/white,
 /area/station/security/brig)
 "iKY" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8
-	},
+/obj/item/toy/sprayoncan,
+/obj/item/toy/xmas_cracker,
 /turf/open/floor/plating,
-/area/station/science/server)
+/area/station/maintenance/port/aft)
 "iLv" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun2";
@@ -16161,6 +16340,12 @@
 /obj/effect/spawner/random/maintenance/seven,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"iNH" = (
+/obj/machinery/ai_slipper{
+	uses = 8
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "iNN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -16256,10 +16441,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "iPQ" = (
 /obj/structure/flora/grass/jungle,
@@ -16267,8 +16449,7 @@
 /area/station/command/heads_quarters/hos)
 "iQf" = (
 /obj/machinery/computer/warrant,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/security/courtroom)
 "iQm" = (
 /obj/effect/spawner/random/maintenance/three,
@@ -16423,7 +16604,7 @@
 /turf/open/floor/plating,
 /area/station/command/teleporter)
 "iUB" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "iUF" = (
@@ -16441,11 +16622,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "iVA" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "iVE" = (
@@ -16501,6 +16682,7 @@
 	name = "Cargo Bay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iWu" = (
@@ -16774,13 +16956,15 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "jdP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/scientist,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "jdU" = (
 /obj/structure/cable,
@@ -16828,6 +17012,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "jfz" = (
@@ -16854,18 +17039,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "jgJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "jha" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sink/directional/west,
@@ -16928,17 +17107,23 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "jhZ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"jie" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"jie" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/siding/dark_green/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "jih" = (
@@ -17019,6 +17204,7 @@
 	dir = 10
 	},
 /obj/structure/chair/stool/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "jkE" = (
@@ -17047,10 +17233,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/fitness)
 "jlx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/turf/closed/wall/r_wall,
+/area/station/science/server)
 "jlU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/scan_consolenew{
@@ -17077,6 +17261,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "jmP" = (
@@ -17117,7 +17302,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/cargo/sorting)
+/area/station/hallway/primary/starboard)
 "joy" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -17133,27 +17318,40 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
+"jph" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jpj" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/computer/mechpad{
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
-"jpo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
+"jpo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "jpr" = (
 /obj/structure/sign/poster/contraband/clown/directional/north,
 /turf/open/floor/plating,
@@ -17262,6 +17460,7 @@
 	name = "Mech Bay"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jsi" = (
@@ -17310,15 +17509,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "jtR" = (
-/obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = 7
-	},
-/obj/item/multitool/circuit,
-/obj/item/multitool/circuit{
-	pixel_x = -8
-	},
-/turf/open/floor/iron,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "jtV" = (
 /obj/machinery/computer/apc_control{
@@ -17354,9 +17546,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "juD" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/computer/security/telescreen{
+	name = "Test Chamber Monitor";
+	network = list("test");
+	pixel_y = 28
+	},
 /turf/open/floor/iron,
 /area/station/science/explab)
 "juF" = (
@@ -17442,6 +17636,11 @@
 "jxb" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	name = "Test Chamber Monitor";
+	network = list("xeno");
+	pixel_y = 32
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "jxi" = (
@@ -17495,17 +17694,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "jyp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "jyR" = (
 /obj/structure/sinkframe{
@@ -17553,6 +17747,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"jAi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "jAC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17675,12 +17876,12 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "jCW" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/cargo/storage"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "jDA" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -17854,16 +18055,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jIb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple,
-/turf/open/floor/plating,
-/area/station/science/server)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "jIo" = (
 /obj/structure/table,
 /obj/item/surgery_tray/full,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "jIJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -17941,9 +18140,15 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
 "jLI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "jLL" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -17965,6 +18170,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"jME" = (
+/obj/structure/transit_tube,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "jMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -17999,12 +18208,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "jOj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "jOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18136,8 +18342,7 @@
 	dir = 4
 	},
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jQA" = (
 /obj/structure/rack,
@@ -18237,15 +18442,9 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
 "jTu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "jTz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -18355,9 +18554,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
 	pixel_y = -31
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -18493,6 +18689,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"kan" = (
+/obj/effect/landmark/start/ai/secondary,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "kaO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -18547,19 +18747,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "kcc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/smartfridge/chemistry/virology/preloaded{
-	density = 0;
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "kck" = (
@@ -18573,9 +18767,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "kcx" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/netpod,
+/obj/effect/turf_decal/tile/brown/full,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "kcG" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -18660,7 +18856,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "kea" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "keh" = (
@@ -18742,7 +18938,7 @@
 /obj/effect/gibspawner/human,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/area/station/maintenance/port)
 "khx" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/east,
@@ -18867,9 +19063,7 @@
 /turf/open/floor/carpet/cyan,
 /area/station/medical/psychology)
 "kmf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "kmj" = (
@@ -18937,7 +19131,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kod" = (
-/obj/machinery/door/window/left/directional/west{
+/obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #1";
 	req_access = list("xenobiology")
 	},
@@ -18954,23 +19148,25 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "koC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/netpod,
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
+"koL" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/chemistry"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"koL" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "koV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -19001,7 +19197,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "kpU" = (
@@ -19016,7 +19213,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "kqF" = (
-/obj/machinery/door/window/left/directional/west{
+/obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #3";
 	req_access = list("xenobiology")
 	},
@@ -19042,21 +19239,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "krl" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/extinguisher,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
-"krn" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
+"krn" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "krx" = (
 /obj/machinery/medical_kiosk{
 	pixel_x = -2;
@@ -19067,7 +19264,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "krP" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -19133,7 +19329,7 @@
 "ktd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -19404,6 +19600,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
+"kAA" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "kAD" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -19512,6 +19713,7 @@
 "kEh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "kEm" = (
@@ -19559,14 +19761,8 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "kFI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "kFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -19596,13 +19792,10 @@
 	dir = 4;
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "kGG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -19612,6 +19805,7 @@
 	name = "Chapel Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron/sepia,
 /area/station/maintenance/port/fore)
 "kHi" = (
@@ -19619,18 +19813,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kHv" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/requests_console{
-	department = "Science";
-	name = "Science Requests Console";
-	pixel_x = 30
-	},
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "kHx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19654,7 +19838,7 @@
 /turf/open/floor/iron,
 /area/station/security)
 "kIc" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
@@ -19671,7 +19855,6 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "kJG" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
@@ -19758,6 +19941,7 @@
 	name = "Hydroponics Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "kMP" = (
@@ -19767,6 +19951,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"kMZ" = (
+/turf/open/floor/iron/dark,
+/area/station/science/circuits)
 "kNk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/chair{
@@ -19775,12 +19962,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "kNB" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/commons/vacant_room/commissary"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "kNX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -19792,10 +19977,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "kNZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/circuit,
 /area/station/science/xenobiology)
 "kOy" = (
@@ -19811,14 +19996,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "kOE" = (
-/obj/item/shrapnel/bullet,
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/machinery/door/airlock/mining{
-	name = "Bitrunners Club"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/cargo/drone_bay)
 "kOS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -19838,13 +20020,17 @@
 /area/station/security/brig)
 "kPp" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/starboard)
 "kPD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/camera/directional/south{
+	c_tag = "Xeno Pens South C";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "kPG" = (
 /obj/effect/turf_decal/tile/red,
@@ -19918,6 +20104,8 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "kRW" = (
@@ -19928,21 +20116,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "kSd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "kSi" = (
@@ -20040,15 +20220,16 @@
 /area/station/security/execution/transfer)
 "kVG" = (
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kVJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","qm")
 	},
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "kVL" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -20091,7 +20272,6 @@
 /area/station/engineering/supermatter)
 "kXJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/station/service/theater)
@@ -20133,8 +20313,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "kYP" = (
@@ -20229,7 +20414,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/area/station/maintenance/port)
 "lbb" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -20252,18 +20437,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lbt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/blue,
+/turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "lbD" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/brown{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
@@ -20367,9 +20552,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ldE" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "lee" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/cafeteria,
@@ -20598,6 +20784,8 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "ljS" = (
@@ -20667,6 +20855,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lmI" = (
@@ -20697,6 +20886,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "lnR" = (
@@ -20713,6 +20903,9 @@
 "lot" = (
 /obj/machinery/modular_computer/preset/cargochat/medical{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
@@ -20747,8 +20940,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "lpm" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/siding/brown{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "lpp" = (
@@ -20779,13 +20974,13 @@
 /area/station/maintenance/port/fore)
 "lpG" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	name = "Brig Desk";
-	req_access = list("security")
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
 	name = "Security Shutters"
+	},
+/obj/machinery/door/window/right/directional/south{
+	name = "Brig Desk";
+	req_access = list("security")
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -20834,9 +21029,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lsD" = (
-/obj/machinery/light/small/broken/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat External Starboard";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "lsG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -20940,6 +21138,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"lvh" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "lvv" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -21022,7 +21224,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "lwZ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
@@ -21136,6 +21338,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/blobstart,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "lAc" = (
@@ -21219,12 +21422,13 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/nuke_storage)
 "lCw" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1;
-	req_access = null
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "mining"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
+/obj/machinery/bouldertech/refinery/smelter,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
@@ -21315,9 +21519,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lFN" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/exodrone_launcher,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "lFS" = (
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/office)
@@ -21464,12 +21669,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lLE" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/theater"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "lLL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21494,16 +21698,13 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "lMk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "lMn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21582,29 +21783,19 @@
 	dir = 10
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lOd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "lOu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "lOH" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/r_wall,
@@ -21695,16 +21886,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "lSQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "lST" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -21764,7 +21951,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
@@ -21947,6 +22133,8 @@
 	pixel_x = -5;
 	pixel_y = 26
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "lZB" = (
@@ -21967,8 +22155,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lZH" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/chair,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "lZU" = (
@@ -22021,6 +22209,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "maw" = (
@@ -22043,14 +22232,25 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"mba" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "mbw" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/service/library)
 "mbG" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat External Port";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "mbQ" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -22059,7 +22259,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "mbW" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
@@ -22290,13 +22490,11 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "mgO" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/item/shrapnel/bullet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "mgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -22315,20 +22513,21 @@
 /turf/closed/wall,
 /area/station/engineering/break_room)
 "mhf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_green{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mhC" = (
-/obj/machinery/atmospherics/pipe/smart/simple{
-	dir = 6
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/science/server)
+/turf/open/space/basic,
+/area/space/nearstation)
 "mhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -22349,12 +22548,7 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "mii" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/structure/closet/bombcloset,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "mim" = (
@@ -22527,7 +22721,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "mmj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/table/wood,
 /obj/machinery/requests_console{
 	department = "Theatre";
@@ -22541,8 +22734,8 @@
 /turf/closed/wall,
 /area/station/service/bar)
 "mmO" = (
-/obj/machinery/module_duplicator,
-/turf/open/floor/iron,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/circuit,
 /area/station/science/circuits)
 "mmU" = (
 /obj/effect/turf_decal/trimline/red/corner{
@@ -22556,7 +22749,6 @@
 "mnr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/window/spawner/directional/north,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/burnchamber)
 "mns" = (
@@ -22598,13 +22790,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "moX" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/science/genetics"
+/obj/structure/chair/office{
+	dir = 1
 	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "mpk" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine{
@@ -22684,7 +22874,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "mqz" = (
@@ -22755,10 +22945,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "mrQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "mrW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -22783,9 +22972,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "mst" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/door/window/left/directional/south{
+	name = "Test Subject Containment";
+	req_access = list("virology")
+	},
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "msG" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
@@ -22981,11 +23173,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "myi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/obj/machinery/digital_clock/directional/north,
+/obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "myk" = (
@@ -23234,23 +23428,28 @@
 /area/station/science/ordnance)
 "mEB" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "mEE" = (
-/obj/structure/cable,
+/obj/machinery/door/airlock/research{
+	name = "Testing Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "experimentation-lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "mFd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23278,11 +23477,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mFN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/showroomfloor,
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "mGm" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -23290,14 +23491,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "mGw" = (
-/obj/effect/spawner/atmos_canister/carbon_dioxide,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/autoname/directional/north{
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/turf/open/floor/iron/dark/telecomms,
+/area/station/science/server)
 "mHE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -23387,6 +23589,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "mKv" = (
@@ -23432,11 +23635,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mLs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "mLD" = (
@@ -23447,17 +23650,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mLQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "mLT" = (
@@ -23484,18 +23687,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "mMx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/cargo_technician,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "mMA" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/stack/spacecash/c10,
@@ -23553,12 +23754,17 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "mNQ" = (
-/turf/closed/wall,
-/area/station/medical/surgery/aft)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "mNS" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
@@ -23577,10 +23783,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "mOY" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/hydroponics"
-	},
-/obj/structure/cable,
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
@@ -23617,7 +23819,8 @@
 /obj/structure/cable,
 /obj/item/radio/intercom{
 	dir = 4;
-	pixel_x = -31
+	pixel_x = -31;
+	pixel_y = 6
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/camera/autoname/directional/west{
@@ -23770,18 +23973,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "mUc" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/station/maintenance/starboard/fore)
 "mUo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/structure/sign/warning/secure_area{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM"
+	},
+/turf/closed/wall/r_wall,
+/area/station/science/server)
 "mUs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23821,11 +24022,10 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "mVg" = (
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/computer/quantum_console,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "mVl" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -23887,12 +24087,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mVM" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/science/explab"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mVN" = (
 /obj/structure/table,
 /obj/machinery/door/window/left/directional/west{
@@ -23929,13 +24127,11 @@
 "mWi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "mWB" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
+/obj/structure/closet/radiation,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/science/explab)
@@ -23961,9 +24157,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -23981,6 +24174,7 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/janitor,
 /obj/structure/chair/stool/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "mYb" = (
@@ -23997,6 +24191,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
 "mYl" = (
@@ -24091,6 +24286,7 @@
 	name = "Gas Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "nbq" = (
@@ -24285,19 +24481,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "ngh" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "ngi" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -24364,6 +24552,20 @@
 /obj/item/seeds/garlic,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"nhk" = (
+/obj/structure/cable,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "nhv" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -24394,6 +24596,8 @@
 "nhN" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/landmark/navigate_destination/disposals,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "nig" = (
@@ -24411,21 +24615,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "niS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/engineering/break_room)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "niY" = (
 /obj/machinery/button/door{
 	id = "Pillshutters";
@@ -24469,13 +24661,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "njG" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/command/heads_quarters/qm"
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "njQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -24504,13 +24694,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nkK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/atmos_canister/nitrogen,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage_shared)
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nkW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24562,10 +24753,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nlX" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "nmk" = (
@@ -24598,6 +24787,7 @@
 /area/station/maintenance/port/aft)
 "nmT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "nnc" = (
@@ -24662,9 +24852,11 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "noh" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/station/science/server)
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "nol" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -24725,9 +24917,15 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "nps" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/window/right/directional/south{
+	name = "Xenobiology Desk";
+	req_access = list("xenobiology")
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "npu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -24799,15 +24997,9 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "nqU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/obj/structure/transit_tube,
+/turf/closed/wall,
+/area/station/maintenance/fore/lesser)
 "nru" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -25009,16 +25201,10 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "nwh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "nwq" = (
 /obj/structure/rack,
 /turf/open/floor/iron/dark,
@@ -25083,6 +25269,7 @@
 /area/station/command/teleporter)
 "nyB" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "nyW" = (
@@ -25129,10 +25316,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "nAe" = (
@@ -25193,11 +25380,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "nCH" = (
-/mob/living/carbon/human/species/monkey{
-	name = "Cubed"
+/obj/structure/bed/dogbed{
+	name = "Bobbernaut's Beb"
 	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/mob/living/basic/slime/pet{
+	slime_type = /datum/slime_type/purple;
+	desc = "The Science Divisions pet slime. Isn't it adorable when it bobbles around?";
+	name = "Bobbernaut"
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/command/heads_quarters/rd)
 "nCI" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
@@ -25206,6 +25398,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
 "nDn" = (
@@ -25219,14 +25412,13 @@
 /turf/open/floor/iron,
 /area/station/security)
 "nDx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "nDF" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -25272,12 +25464,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "nEw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/spawner/random/trash/garbage,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "nEN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25301,11 +25493,11 @@
 	},
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nEY" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/modular_computer/preset/cargochat/science,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "nEZ" = (
@@ -25396,11 +25588,11 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "nIi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_green{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -25429,6 +25621,7 @@
 	name = "Crematorium Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "nJu" = (
@@ -25445,8 +25638,9 @@
 /area/station/medical/pharmacy)
 "nJJ" = (
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/photocopier,
-/obj/item/clipboard,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","qm")
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "nKb" = (
@@ -25529,7 +25723,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "nMz" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -25544,7 +25737,7 @@
 "nMI" = (
 /obj/effect/spawner/atmos_canister/air,
 /turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/area/station/maintenance/port)
 "nMO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -25855,12 +26048,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "nUx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "nUM" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
@@ -25876,7 +26068,7 @@
 	pixel_x = 3;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
@@ -25941,8 +26133,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "nXv" = (
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/storage)
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/computer/atmos_control/ordnancemix{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "nXC" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -25969,16 +26166,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nYi" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "nYk" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
 "nYv" = (
 /mob/living/basic/goat/pete{
-	desc = "The chefs most 'trusted' pet Goat. Just don't stare at him too long.";
-	name = "Pete"
+	desc = "The chefs most 'trusted' pet Goat. Just don't stare at him too long."
 	},
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
@@ -26071,12 +26267,9 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "nZP" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Quartermaster's Desk";
-	name = "Quartermaster RC"
+/obj/machinery/keycard_auth{
+	pixel_x = 24
 	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "nZV" = (
@@ -26157,10 +26350,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/warning/biohazard{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/structure/sign/warning/biohazard/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "och" = (
@@ -26183,6 +26373,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "odb" = (
@@ -26250,7 +26441,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oeI" = (
-/turf/open/floor/iron,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/circuit,
 /area/station/science/circuits)
 "oeP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -26312,17 +26505,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ogI" = (
-/obj/machinery/netpod,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "ogP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"ogV" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "ogY" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
@@ -26424,17 +26621,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ojr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat External Fore";
+	network = list("minisat")
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/space/basic,
+/area/space)
 "oju" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26493,13 +26685,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "olc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/north,
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "olq" = (
@@ -26596,9 +26788,6 @@
 "ooa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/toilet"
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -26644,9 +26833,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -26908,12 +27094,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ovt" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/medical/psychology"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "ovE" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/north,
@@ -26960,8 +27145,20 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "owN" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/dark,
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
+"owS" = (
+/obj/structure/cable,
+/obj/machinery/button/door{
+	id = "misclab";
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "oxk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -26996,6 +27193,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oyq" = (
@@ -27106,11 +27304,11 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "oBa" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/mechpad,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "oBj" = (
 /obj/structure/mineral_door/wood{
@@ -27190,6 +27388,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "oEG" = (
@@ -27206,6 +27405,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "oFu" = (
@@ -27234,10 +27434,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "oGq" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "oGP" = (
@@ -27287,15 +27487,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
 	},
-/mob/living/basic/slime/pet{
-	slime_type = /datum/slime_type/purple;
-	desc = "The Science Divisions pet slime. Isn't it adorable when it bobbles around?";
-	name = "Bobbernaut"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "oHz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27333,11 +27528,14 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "oIu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat Chamber Foyer";
+	network = list("minisat")
+	},
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "oII" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -27374,10 +27572,6 @@
 /obj/item/target/alien,
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "oKE" = (
@@ -27569,22 +27763,17 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "oQn" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "oQz" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/airalarm/directional/south,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 11
+/obj/machinery/door/poddoor/shutters{
+	id = "stationawaygate";
+	name = "Gateway Access Shutters"
 	},
-/turf/open/floor/iron,
-/area/station/science/circuits)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/gateway)
 "oQO" = (
 /obj/item/book/random,
 /obj/effect/decal/cleanable/cobweb,
@@ -27634,12 +27823,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/science/explab)
 "oSC" = (
@@ -27658,6 +27841,12 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"oSQ" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/command/heads_quarters/rd)
 "oTg" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
@@ -27670,10 +27859,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oTr" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/machinery/stasis,
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 8
 	},
-/obj/machinery/stasis,
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "oTB" = (
@@ -27689,6 +27878,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "oTL" = (
@@ -27782,13 +27973,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "oVU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining"
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/atmos_canister/air,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage_shared)
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "oWb" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/latex,
@@ -27831,23 +28020,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
 "oXw" = (
-/obj/structure/cable,
-/obj/machinery/button/door{
-	id = "misclab";
-	pixel_y = 25
+/obj/structure/table,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science{
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	dir = 4;
-	name = "Test Chamber Monitor";
-	network = list("xeno");
-	pixel_x = -31;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/science/explab)
 "oXI" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -27901,12 +28080,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oYE" = (
-/obj/machinery/atmospherics/pipe/smart/simple{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/station/science/server)
+/area/station/maintenance/port/aft)
 "oYV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -28099,11 +28276,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "pdM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /mob/living/basic/parrot/poly,
 /obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -28156,8 +28333,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "peT" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -28195,6 +28373,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "phn" = (
@@ -28357,17 +28536,19 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "pjV" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "pkv" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/smartfridge/petri/preloaded,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "pkA" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/west,
@@ -28399,9 +28580,6 @@
 "plL" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/item/pai_card{
 	pixel_x = -3;
 	pixel_y = 3
@@ -28509,13 +28687,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "poS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "poT" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -28611,6 +28789,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "pqS" = (
@@ -28641,6 +28820,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"prm" = (
+/obj/structure/closet/toolcloset,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "prp" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -28899,27 +29084,18 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pye" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/siding/dark_green/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pyy" = (
-/obj/item/shrapnel/bullet,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "pyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -28951,6 +29127,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"pzm" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "pzq" = (
 /obj/structure/table,
 /obj/item/seeds/wheat/rice,
@@ -29005,7 +29188,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "pAk" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
@@ -29196,15 +29379,16 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "pGY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "pHb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "pHe" = (
@@ -29268,12 +29452,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pIs" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "pIF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29400,7 +29583,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "pLB" = (
-/obj/machinery/piratepad/civilian,
+/obj/machinery/computer/piratepad_control/civilian{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "pLD" = (
@@ -29535,8 +29720,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
@@ -29637,8 +29822,11 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "pRG" = (
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "pSn" = (
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/iron,
@@ -29657,6 +29845,13 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"pSA" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "pSB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -29694,6 +29889,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "pSP" = (
@@ -29756,9 +29952,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "pUA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -29788,11 +29981,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pVw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pVE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -29870,6 +30065,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "pYt" = (
@@ -29900,9 +30096,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/end{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "pYZ" = (
@@ -29935,7 +30132,9 @@
 /area/station/hallway/primary/fore)
 "pZy" = (
 /obj/machinery/oven/range,
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "pZK" = (
@@ -30006,9 +30205,16 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain)
 "qaB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "qaP" = (
 /obj/structure/chair/stool/directional/east,
@@ -30030,12 +30236,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qbD" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/commons/storage/art"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "qbG" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/iron,
@@ -30069,6 +30275,7 @@
 	name = "Mining Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qcd" = (
@@ -30171,9 +30378,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "qfN" = (
-/obj/item/ai_module/toy_ai,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qga" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron/showroomfloor,
@@ -30199,14 +30408,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/commons/dorms)
 "qhd" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
 	},
 /obj/machinery/stasis,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "qhe" = (
@@ -30331,15 +30540,11 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/office)
 "qkK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/brm,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "qkQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -30357,9 +30562,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -30387,6 +30589,7 @@
 "qlW" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "qmh" = (
@@ -30450,8 +30653,10 @@
 "qoB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/stripes/box,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "qoD" = (
@@ -30512,6 +30717,7 @@
 	name = "Law Office Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qpj" = (
@@ -30669,14 +30875,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
 "qtC" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "qtF" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
@@ -30695,9 +30898,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south{
-	areastring = "/area/station/service/bar"
-	},
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
@@ -30769,12 +30969,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qvJ" = (
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "qwk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
@@ -30828,22 +31032,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "qwD" = (
-/obj/machinery/door/window/left/directional/west{
-	name = "Containment Pen #4";
-	req_access = list("xenobiology")
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "qwG" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/maintenance/disposal"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "qwH" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -30873,20 +31071,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/camera/autoname/directional/west{
-	network = list("ss13","qm")
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "qxg" = (
 /obj/structure/cable,
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "qxi" = (
@@ -30914,11 +31106,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "qxZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/science/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "qyp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -30996,6 +31191,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "qzZ" = (
@@ -31031,12 +31227,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qAP" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/science/server)
+/obj/effect/turf_decal/stripes/corner,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "qAQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -31148,6 +31342,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "qCx" = (
@@ -31179,9 +31375,6 @@
 /area/station/science/robotics/mechbay)
 "qDU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -31252,6 +31445,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "qFY" = (
@@ -31306,6 +31500,7 @@
 /area/station/maintenance/disposal/incinerator)
 "qHm" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "qHJ" = (
@@ -31329,11 +31524,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qHT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/closet/wardrobe/miner,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "qHW" = (
@@ -31516,13 +31708,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qKK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "qKN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31550,10 +31740,7 @@
 	},
 /area/station/hallway/primary/central)
 "qLu" = (
-/obj/structure/closet/l3closet/scientist{
-	pixel_x = -2
-	},
-/obj/machinery/light/directional/north,
+/obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "qLE" = (
@@ -31566,6 +31753,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"qLX" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
+"qMb" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "Drone Hangar"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "qMi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -31580,9 +31784,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
@@ -31590,19 +31791,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "qMw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/science/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "qME" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -31811,16 +32009,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "qRp" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "qRu" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
@@ -31877,12 +32070,9 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "qSh" = (
-/obj/machinery/computer/rdservercontrol,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/effect/spawner/random/clothing/wardrobe_closet,
 /turf/open/floor/plating,
-/area/station/science/server)
+/area/station/maintenance/port/aft)
 "qSj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -32012,14 +32202,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "qUy" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/ai_monitored/command/storage/eva)
+/obj/machinery/computer/exodrone_control_console,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "qUC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -32166,12 +32352,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "qXt" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/security/courtroom"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "qXG" = (
 /obj/structure/light_construct{
 	dir = 4
@@ -32184,12 +32369,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "qXX" = (
-/obj/structure/sign/warning/secure_area{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM"
+/obj/machinery/door/window/left/directional/south{
+	name = "Cytology Chamber";
+	req_access = list("science")
 	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/aft)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "qYf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -32228,11 +32414,11 @@
 /turf/closed/wall,
 /area/station/science/research)
 "qYu" = (
-/obj/effect/spawner/atmos_canister/air,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "qYw" = (
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
@@ -32241,6 +32427,7 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
+/obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "qYP" = (
@@ -32292,10 +32479,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "qZR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "rac" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -32338,11 +32528,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rbD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "rbP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -32409,14 +32598,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "rdk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat Chamber Aft";
+	network = list("minisat")
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "rdA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -32445,7 +32632,6 @@
 /obj/machinery/power/apc/auto_name/directional/north{
 	areastring = "/area/station/medical/virology"
 	},
-/obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -32503,8 +32689,8 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/rd)
 "rfN" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/obj/item/storage/bag/money,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "rfP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -32596,11 +32782,12 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/fitness)
 "rio" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = 0
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "riw" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -32666,10 +32853,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rkb" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/kitchen"
-	},
-/obj/structure/cable,
 /obj/machinery/food_cart,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
@@ -32704,7 +32887,9 @@
 /area/station/security/brig)
 "rlK" = (
 /obj/machinery/griddle,
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "rlX" = (
@@ -32722,6 +32907,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "rmh" = (
@@ -32754,6 +32941,8 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/briefcase/secure,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "rnr" = (
@@ -32796,19 +32985,28 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "rox" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 14
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "roA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "roE" = (
 /obj/item/beacon,
@@ -32844,6 +33042,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "rpJ" = (
@@ -32892,12 +33096,10 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/captain)
 "rqO" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "rrm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32960,28 +33162,18 @@
 /turf/open/space,
 /area/space/nearstation)
 "rsh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
-"rsw" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology Break Room";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
+"rsw" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "rsF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -33012,9 +33204,6 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
 "rsV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
@@ -33162,15 +33351,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rvA" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "testlab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = 2;
-	req_access = list("xenobiology")
-	},
-/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "rvO" = (
@@ -33206,21 +33386,15 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/dark_green{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rwK" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/janitor"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "rwL" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33329,10 +33503,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ryS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ryW" = (
 /obj/machinery/light/directional/east,
@@ -33380,15 +33557,14 @@
 "rAh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "rAn" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/ai_monitored/command/storage/eva)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/lesser)
 "rAz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
@@ -33516,6 +33692,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rCW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/slime_jelly_donuts,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "rDg" = (
@@ -33547,12 +33728,14 @@
 	name = "library sorting disposal pipe";
 	sortType = 16
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "rDx" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "rDT" = (
@@ -33622,9 +33805,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "rFu" = (
@@ -33655,10 +33836,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "rFR" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/construction/mining/aux_base"
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "rFW" = (
@@ -33679,12 +33858,12 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rGn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 6
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Xeno Kill Chamber";
 	network = list("ss13","rd")
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/station/science/xenobiology)
@@ -33715,11 +33894,10 @@
 	},
 /area/station/service/theater)
 "rHl" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/end{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "rHo" = (
@@ -33766,9 +33944,6 @@
 /area/station/science/research)
 "rIO" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","rd")
 	},
@@ -33781,10 +33956,10 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "rJT" = (
-/obj/effect/turf_decal/stripes/box,
 /obj/machinery/hydroponics/constructable{
 	pixel_y = 10
 	},
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "rJY" = (
@@ -33902,13 +34077,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "rNB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining";
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rNG" = (
@@ -33919,6 +34088,7 @@
 	name = "chemistry sorting disposal pipe";
 	sortType = 11
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rNL" = (
@@ -33934,9 +34104,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
 	},
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","rd")
@@ -33986,6 +34153,12 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"rOE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "rPt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/computer/operating{
@@ -33993,7 +34166,7 @@
 	name = "Robotics Operating Computer"
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "rPz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -34156,13 +34329,17 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "rUj" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
-/turf/open/floor/iron/dark,
-/area/station/security/courtroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "rUn" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/computer/camera_advanced/base_construction/aux{
@@ -34211,14 +34388,14 @@
 /turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "rWr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/science/server)
 "rWW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -34391,8 +34568,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "sbY" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining"
+	},
+/obj/machinery/brm,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "scc" = (
@@ -34440,15 +34620,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination/library,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "scx" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/effect/spawner/random/maintenance/closet,
 /turf/open/floor/plating,
-/area/station/science/server)
+/area/station/maintenance/port/aft)
 "scz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -34456,15 +34634,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "scL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "sdw" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock"
@@ -34594,14 +34770,13 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "sgp" = (
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/vending/monkey,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "sgw" = (
@@ -34626,22 +34801,17 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "sgW" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/turf/closed/wall,
+/area/station/cargo/drone_bay)
 "sgY" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "shk" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -34719,12 +34889,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "sjX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "sjZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34894,11 +35064,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "spO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/machinery/monkey_recycler,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","qm")
+	},
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "spS" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -34919,6 +35092,10 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"sqg" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/science/robotics/mechbay)
 "sqp" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -35051,22 +35228,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ssO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	areastring = "/area/station/service/lawoffice"
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "stc" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -35090,18 +35256,13 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "stV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "sux" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35169,14 +35330,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "sxC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/fax{
 	fax_name = "Research Director's Office";
 	name = "Research Director's Fax Machine"
 	},
 /obj/structure/table,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "sxH" = (
@@ -35286,10 +35445,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -35350,6 +35509,7 @@
 /area/station/maintenance/solars/starboard/fore)
 "sDK" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "sDL" = (
@@ -35460,12 +35620,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "sHt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit)
+/obj/item/gun/ballistic/revolver/russian,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "sHw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35493,7 +35652,6 @@
 	network = list("ss13","rd");
 	view_range = 10
 	},
-/obj/structure/table,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
@@ -35713,7 +35871,8 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "sPi" = (
 /obj/structure/cable,
@@ -35727,23 +35886,19 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "sPL" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/turf/open/floor/plating,
-/area/station/science/server)
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/coin/gold,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "sQa" = (
-/obj/machinery/computer/security/telescreen{
-	name = "Test Chamber Monitor";
-	network = list("test");
-	pixel_y = 28
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
-/obj/structure/table,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science{
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/explab)
 "sQv" = (
@@ -35853,9 +36008,8 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/razor,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "sTx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -35871,7 +36025,7 @@
 	cycle_id = "sci-toxins-passthrough"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "sTy" = (
 /obj/effect/turf_decal/tile/blue{
@@ -35913,7 +36067,8 @@
 /area/station/maintenance/port/fore)
 "sUN" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -35925,11 +36080,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "sVh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "sVm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36026,14 +36179,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "sYT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sYU" = (
 /obj/item/paint/anycolor{
 	pixel_x = 8
@@ -36072,9 +36226,11 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central)
 "tak" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "taI" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -36111,6 +36267,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "tbz" = (
@@ -36125,12 +36282,15 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/hos)
 "tbD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/ai_monitored/turret_protected/ai)
 "tbM" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -36171,9 +36331,6 @@
 /obj/machinery/light/small/directional/north,
 /obj/item/radio/intercom{
 	pixel_y = 25
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -36218,6 +36375,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/storage/dice,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "tdo" = (
@@ -36260,14 +36418,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "teD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "teP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -36288,7 +36442,9 @@
 /obj/effect/turf_decal/tile/holiday/random{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "teZ" = (
@@ -36353,6 +36509,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "thg" = (
@@ -36563,18 +36721,15 @@
 /area/station/maintenance/starboard/aft)
 "tlL" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "tlN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/circuit/telecomms/server,
-/area/station/science/server)
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "tlO" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -36695,10 +36850,10 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "tpX" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/machinery/cryo_cell,
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 8
 	},
-/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "tqd" = (
@@ -36781,7 +36936,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "tsB" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
@@ -36852,11 +37007,16 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "tuO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "tuP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36931,16 +37091,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "txB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/sign/warning/vacuum/directional/south,
-/obj/machinery/bouldertech/refinery,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/machinery/computer/shuttle/mining{
+	dir = 1;
+	req_access = null
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "txC" = (
 /obj/structure/cable,
@@ -36985,10 +37144,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "tzc" = (
 /obj/machinery/light/directional/east,
 /obj/structure/chair/stool/directional/south,
@@ -37107,16 +37264,19 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "tCb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/no_smoking/directional/south,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/command{
+	name = "Server Room"
 	},
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/station/science/server)
 "tCd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37126,6 +37286,12 @@
 "tCf" = (
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"tCg" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/kitchen)
 "tCq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37149,6 +37315,7 @@
 	pixel_x = -8;
 	pixel_y = -23
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "tCA" = (
@@ -37157,6 +37324,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "tCB" = (
@@ -37198,11 +37367,11 @@
 "tEd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/window/left/directional/west{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/south{
 	name = "Armory";
 	req_access = list("armory")
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "tEe" = (
@@ -37236,6 +37405,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tEE" = (
@@ -37347,6 +37517,8 @@
 /obj/machinery/camera/autoname/directional/east{
 	network = list("ss13","qm")
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "tHl" = (
@@ -37599,9 +37771,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "tPd" = (
-/obj/structure/chair/office,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen #2";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "tPe" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
@@ -37638,20 +37813,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tPU" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 5
 	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "tPV" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -37758,15 +37924,12 @@
 /area/station/science/explab)
 "tTo" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/chair,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "tTM" = (
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -37855,18 +38018,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "tVI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/computer/order_console/bitrunning,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "tVN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "tVX" = (
@@ -37991,14 +38150,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "tYk" = (
-/obj/structure/table,
-/obj/item/mmi,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/ecto_sniffer{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "tYD" = (
 /obj/effect/turf_decal/bot,
@@ -38025,9 +38181,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "uau" = (
-/obj/structure/table,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/showroomfloor,
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/xenobio_guide/directional/east,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "uaw" = (
 /obj/structure/closet/emcloset,
@@ -38056,6 +38212,8 @@
 /obj/item/melee/flyswatter,
 /obj/item/queen_bee/bought,
 /obj/item/clothing/head/utility/beekeeper_head,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ubj" = (
@@ -38063,21 +38221,17 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "ubm" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
+/obj/machinery/requests_console/directional/south{
+	department = "AI";
+	name = "AI Chamber Requests Console";
+	pixel_y = 30
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "ubu" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/sepia,
@@ -38112,10 +38266,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "ubH" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -38137,6 +38291,10 @@
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
 /area/station/security/prison)
+"ucw" = (
+/obj/machinery/chem_master,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "ucA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -38251,6 +38409,7 @@
 "ufN" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/order_console/mining,
+/obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "ufP" = (
@@ -38308,8 +38467,15 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "uil" = (
-/turf/open/floor/plating,
-/area/station/commons/storage/emergency/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "uiw" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -38359,17 +38525,13 @@
 /area/station/service/library)
 "ujt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "ujE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -38378,20 +38540,17 @@
 	name = "Biohazard Containment Door"
 	},
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ujF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Storage"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "ujG" = (
 /turf/closed/wall,
 /area/station/medical/surgery)
@@ -38514,16 +38673,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "unw" = (
-/obj/machinery/computer/quantum_console{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "unE" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/shower/directional/north,
@@ -38570,13 +38724,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uos" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 1;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/station/science/server)
+/obj/item/clothing/head/costume/powdered_wig,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "uou" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -38687,9 +38837,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "uqm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -38785,10 +38932,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"uso" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "usH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "usR" = (
@@ -38925,12 +39079,12 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance)
 "uvX" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "uwk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -38968,10 +39122,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "uxo" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "uxq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39059,6 +39211,10 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"uBl" = (
+/obj/item/clothing/glasses/monocle,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "uBo" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -39334,7 +39490,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "uIA" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -39375,6 +39531,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "uJG" = (
@@ -39399,7 +39556,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "uJY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39419,9 +39576,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "uKU" = (
-/obj/machinery/computer/exodrone_control_console,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "uKW" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -39460,10 +39620,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "uLP" = (
@@ -39536,18 +39695,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "uMV" = (
-/obj/machinery/power/apc/auto_name/directional/west{
-	areastring = "/area/station/cargo/sorting"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uNt" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 4
@@ -39587,6 +39737,7 @@
 /area/station/medical/medbay/central)
 "uPu" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "uPE" = (
@@ -39622,7 +39773,7 @@
 /area/station/security/brig)
 "uPS" = (
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "uPX" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/cyan,
@@ -39638,6 +39789,7 @@
 	name = "Jury"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "uQK" = (
@@ -39668,8 +39820,14 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "uRs" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "mining"
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "uRG" = (
 /obj/structure/disposalpipe/segment{
@@ -39699,6 +39857,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "uSn" = (
@@ -39751,6 +39910,12 @@
 "uST" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
+"uTq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "uTH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -39775,9 +39940,6 @@
 	id = "toxinsdriver";
 	pixel_x = -5;
 	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
 	},
 /obj/machinery/research/anomaly_refinery,
 /turf/open/floor/iron/dark,
@@ -39852,6 +40014,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "uVX" = (
@@ -39871,6 +40034,7 @@
 	id = "JaniShutters";
 	name = "Custodial Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "uWw" = (
@@ -39958,11 +40122,13 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "uYC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "uYG" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
@@ -40026,17 +40192,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uZw" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet/any,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/cleanliness/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "uZP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -40074,10 +40239,10 @@
 /area/station/service/library)
 "vaS" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "vbd" = (
@@ -40140,13 +40305,17 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "vbV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/machinery/light/floor{
+	brightness = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "vbX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -40215,6 +40384,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "veO" = (
@@ -40291,9 +40461,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vgu" = (
-/obj/docking_port/stationary/escape_pod,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "vgx" = (
 /obj/structure/table,
 /obj/item/stock_parts/capacitor{
@@ -40352,22 +40524,19 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "vig" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "viz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "viI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40476,6 +40645,7 @@
 	dir = 8
 	},
 /obj/machinery/digital_clock/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "vkQ" = (
@@ -40580,17 +40750,26 @@
 /turf/open/floor/grass,
 /area/station/security/prison)
 "voq" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Drone Hangar"
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = 20
 	},
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "vov" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Xeno Pens North B";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "voy" = (
 /obj/structure/cable,
@@ -40720,19 +40899,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vsO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/atmos_canister/oxygen,
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "vsS" = (
 /obj/structure/table,
 /obj/item/ai_module/core/full/asimov,
 /obj/item/ai_module/core/freeformcore,
 /obj/machinery/door/window/left/directional/west{
 	name = "Core Modules";
-	req_access = list("captain")
+	req_access = list("captain");
+	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/spawner/random/aimodule/harmless,
@@ -40788,10 +40969,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -40819,9 +41000,13 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "vuk" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/machinery/light/floor{
+	brightness = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/area/station/science/cytology)
 "vuu" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -40851,7 +41036,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vuT" = (
-/obj/machinery/airalarm/directional/south,
 /obj/structure/table/wood,
 /obj/item/food/baguette,
 /obj/item/lipstick/random{
@@ -40902,12 +41086,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vvH" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics2";
-	name = "Robotics Lab Shutters"
-	},
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/turf/open/floor/circuit,
 /area/station/science/circuits)
 "vvJ" = (
 /obj/structure/sign/warning/pods/directional/west,
@@ -40965,6 +41148,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/navigate_destination/tools,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "vxf" = (
@@ -40973,12 +41157,15 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
 "vxh" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "vxF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -41127,6 +41314,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "vAR" = (
@@ -41143,10 +41331,8 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "vBw" = (
-/obj/structure/closet/secure_closet/cytology,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/closed/wall/r_wall,
+/area/station/science/cytology)
 "vBH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -41181,13 +41367,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "vCK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/window/right/directional/east{
-	name = "Xenobiology Desk";
-	req_access = list("xenobiology")
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vCP" = (
 /obj/effect/turf_decal/plaque{
@@ -41281,10 +41469,10 @@
 "vEc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "vET" = (
@@ -41449,8 +41637,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "vGT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "vHt" = (
@@ -41472,11 +41661,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vIf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/stripes/box,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "vIl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41491,6 +41678,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"vID" = (
+/obj/machinery/camera/motion/directional/north{
+	network = list("minisat");
+	c_tag = "MiniSat Chamber Fore"
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "vIJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -41520,17 +41714,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vJv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "vJJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -41568,10 +41754,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vKA" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "vKV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/newscaster/directional/south,
@@ -41592,6 +41780,8 @@
 /obj/structure/rack,
 /obj/item/storage/briefcase,
 /obj/item/toy/plush/carpplushie,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "vLX" = (
@@ -41637,10 +41827,6 @@
 /area/station/security/warden)
 "vMK" = (
 /obj/machinery/firealarm/directional/west,
-/mob/living/basic/mothroach{
-	desc = "That's mining's pet mothroach Aemilia. Affectionately known as the mini Darkheart they're quite sweet, offering weary miners reassurance after long days of carving hardened basalt and running from megafauna.";
-	name = "Aemilia"
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vMW" = (
@@ -41662,8 +41848,12 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vNm" = (
-/turf/open/floor/iron/stairs/old,
-/area/station/maintenance/starboard/lesser)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "vNu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41693,6 +41883,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "vOu" = (
@@ -41706,10 +41897,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vOC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/computer/rdservercontrol{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "vOJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41789,9 +41982,6 @@
 /area/station/command/heads_quarters/hos)
 "vQI" = (
 /obj/machinery/suit_storage_unit/rd,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/camera/autoname/directional/east{
 	network = list("ss13","rd")
 	},
@@ -41859,6 +42049,7 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "vTO" = (
@@ -41915,6 +42106,7 @@
 /area/station/maintenance/port/aft)
 "vUw" = (
 /obj/machinery/light/small/directional/east,
+/obj/structure/sign/warning/pods/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "vUK" = (
@@ -41945,20 +42137,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "vWk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "vWn" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/item/seeds/banana,
@@ -42092,8 +42275,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "waR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "mining"
+	},
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -42161,8 +42347,14 @@
 /area/station/command/bridge)
 "wcd" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "wce" = (
 /turf/open/floor/plating,
@@ -42251,7 +42443,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "wel" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -42325,8 +42517,14 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"wfQ" = (
+/obj/machinery/requests_console/directional/west,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "wfW" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -42367,15 +42565,10 @@
 /turf/closed/wall,
 /area/station/service/kitchen)
 "wgj" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/server)
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/shoes/laceup,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "wgs" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
@@ -42443,11 +42636,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "win" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/mining/glass{
+	id_tag = "innercargo";
+	name = "Bitrunning Club"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/old{
+	dir = 8
+	},
+/area/station/cargo/bitrunning/den)
 "wiq" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -42513,8 +42713,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/autolathe,
+/obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "wjJ" = (
@@ -42530,12 +42730,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wjQ" = (
-/obj/machinery/netpod,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/janitor)
 "wkg" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -42688,12 +42889,9 @@
 	},
 /area/station/hallway/primary/central)
 "wnp" = (
-/obj/structure/secure_safe/caps_spare{
-	pixel_x = 5;
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/station/command/bridge)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "wnK" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -42833,12 +43031,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "wqD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "wqM" = (
 /obj/effect/spawner/random/maintenance,
@@ -42901,6 +43097,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "wrO" = (
@@ -42908,6 +43105,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wrT" = (
@@ -42943,9 +43141,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "wsA" = (
-/obj/item/shrapnel/bullet,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/quantum_server,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "wsQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -42978,12 +43177,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "wuf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "wui" = (
@@ -42993,6 +43193,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"wuw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wuX" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -43054,12 +43261,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "wwt" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/hydroponics/garden"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "wwL" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -43358,7 +43564,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/dark_green{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -43383,13 +43589,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wDi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -43405,13 +43614,12 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "wDk" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/atmos_canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
-/area/station/engineering/storage_shared)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "wDo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -43550,9 +43758,6 @@
 /area/station/cargo/storage)
 "wGa" = (
 /obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "wGh" = (
@@ -43610,15 +43815,15 @@
 /turf/open/floor/plating,
 /area/station/security/brig)
 "wHB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/random/bureaucracy/pen,
+/turf/open/floor/iron,
+/area/station/science/explab)
 "wHR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43686,6 +43891,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "wKK" = (
@@ -43702,6 +43908,9 @@
 /area/station/ai_monitored/command/storage/eva)
 "wLd" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/modular_computer/preset/cargochat/science{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
 "wLo" = (
@@ -43951,10 +44160,10 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "wRv" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "wRE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -44109,11 +44318,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wVw" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/leafy,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "wVA" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine,
@@ -44151,10 +44359,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "wWS" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/structure/chair,
+/obj/effect/turf_decal/siding/white/end{
 	dir = 8
 	},
-/obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "wWT" = (
@@ -44180,12 +44388,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wXw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "wXy" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -44211,6 +44421,7 @@
 	name = "Auxiliary Tool Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "wYh" = (
@@ -44396,6 +44607,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "xdE" = (
@@ -44415,18 +44627,18 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "xdX" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/computer/order_console/bitrunning,
-/turf/open/floor/plating,
-/area/station/cargo/bitrunning/den)
-"xef" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes,
+/obj/machinery/door/airlock/atmos{
+	name = "Gas Storage"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/engineering/supermatter/room)
+"xef" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "xes" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -44460,9 +44672,8 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xeS" = (
-/obj/machinery/rnd/server/master,
-/turf/open/floor/circuit/telecomms/server,
-/area/station/science/server)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "xeT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -44504,6 +44715,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin/construction,
 /obj/item/storage/crayons,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "xfD" = (
@@ -44548,10 +44760,11 @@
 /obj/structure/table/optable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "xgU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xgW" = (
@@ -44568,11 +44781,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xhc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 10
+/obj/structure/table/glass,
+/obj/structure/microscope,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -4;
+	pixel_y = -11
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "xhf" = (
 /obj/machinery/requests_console{
 	department = "Head of Personnel's Desk";
@@ -44615,8 +44833,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "xix" = (
-/obj/machinery/mechpad,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics2";
+	name = "Robotics Lab Shutters"
+	},
+/turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xiU" = (
 /turf/open/floor/wood,
@@ -44664,12 +44886,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "xlh" = (
-/obj/machinery/door/window/left/directional/west{
-	name = "Containment Pen #5";
-	req_access = list("xenobiology")
+/obj/machinery/door/poddoor/shutters{
+	id = "aux_base_shutters";
+	name = "Auxillary Base Shutters"
 	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "xlR" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -44690,7 +44913,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery)
 "xmG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -44748,6 +44971,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "xni" = (
@@ -44778,11 +45002,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "xnr" = (
-/obj/structure/table,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/hello_world,
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
 /area/station/science/circuits)
 "xnw" = (
 /obj/effect/turf_decal/tile/blue{
@@ -44861,6 +45085,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/botanical_waste,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "xpA" = (
@@ -44902,9 +45127,6 @@
 "xpW" = (
 /obj/machinery/doppler_array{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -44981,22 +45203,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xrW" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/vending/cola,
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/machinery/vending/cola,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "xrY" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east{
-	areastring = "/area/station/service/library"
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "xsf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -45116,12 +45335,13 @@
 /area/station/engineering/engine_smes)
 "xvK" = (
 /obj/effect/landmark/start/cargo_technician,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xvZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "xwc" = (
 /turf/closed/wall/r_wall,
 /area/station/science/lab)
@@ -45192,10 +45412,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xxL" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "xxV" = (
@@ -45232,14 +45452,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "xyI" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/server)
+/obj/item/knife,
+/obj/effect/gibspawner/confetti,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "xyN" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -45341,6 +45557,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"xBA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "xBL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -45522,6 +45743,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 12
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -45744,13 +45968,12 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "xKv" = (
-/obj/structure/table/glass,
-/obj/structure/microscope{
-	pixel_x = 3;
-	pixel_y = 1
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/science/robotics/lab)
 "xKE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -45872,6 +46095,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool/directional/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xOe" = (
@@ -46010,10 +46234,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xSL" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/vending/snack,
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/machinery/vending/snack,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "xSM" = (
@@ -46056,9 +46280,6 @@
 /area/station/holodeck/rec_center)
 "xTa" = (
 /obj/structure/closet/secure_closet/research_director,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/item/taperecorder{
 	pixel_x = -3
 	},
@@ -46140,10 +46361,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "xUC" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -46160,11 +46381,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "xVe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/l3closet/scientist,
-/turf/open/floor/iron,
-/area/station/science/ordnance/storage)
+/obj/machinery/rnd/server/master,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/circuit/telecomms/server,
+/area/station/science/server)
 "xVp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -46173,11 +46393,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xVT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "xWD" = (
 /obj/item/paper/fluff/jobs/security/beepsky_mom,
 /turf/open/floor/plating,
@@ -46227,11 +46445,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"xYK" = (
-/obj/effect/turf_decal/stripes/corner{
+"xYA" = (
+/obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
+"xYK" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "xYO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -46325,13 +46550,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "yaC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "yaF" = (
@@ -46448,6 +46673,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"ydq" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "ydr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -46596,10 +46826,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ygS" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/obj/structure/closet,
+/obj/item/circuitboard/machine/exoscanner,
+/obj/item/circuitboard/machine/exoscanner,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/fuel_pellet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "ygV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56669,7 +56906,7 @@ ggx
 bXj
 neF
 tcn
-nps
+lOd
 sof
 mSB
 neF
@@ -58253,7 +58490,7 @@ bQZ
 utW
 mDS
 eOL
-nDx
+hSZ
 bOe
 aPV
 bVX
@@ -58481,7 +58718,7 @@ vlu
 mDS
 eOL
 elT
-nps
+kmf
 dAC
 jOX
 cag
@@ -58676,7 +58913,7 @@ dbt
 qYw
 lpy
 hyr
-xrY
+gXq
 fzg
 gXq
 siE
@@ -58695,7 +58932,7 @@ lZu
 fxJ
 teQ
 xxr
-tsp
+gRc
 vTy
 aOa
 mUs
@@ -58704,11 +58941,11 @@ vCX
 uGM
 ctE
 cqf
-hdi
+pbL
 mDS
 eOL
 bjM
-nps
+kmf
 dAC
 jOX
 mnr
@@ -59364,7 +59601,7 @@ rFl
 uje
 xPc
 eXk
-eXk
+hzV
 uje
 qdM
 piv
@@ -59388,8 +59625,8 @@ cqf
 dwF
 akJ
 eOL
-hSZ
-nps
+uKU
+kmf
 dAC
 xes
 bOY
@@ -59582,7 +59819,7 @@ beZ
 beZ
 pVp
 beZ
-wwt
+beZ
 kss
 qYw
 nHy
@@ -59616,7 +59853,7 @@ pbL
 sLg
 eOL
 xIg
-nUx
+rFs
 dAC
 pXB
 dAC
@@ -59843,7 +60080,7 @@ fmc
 gcC
 eOL
 vkK
-nps
+kmf
 dAC
 bOY
 dAC
@@ -60052,9 +60289,9 @@ rxJ
 dja
 gLK
 ksv
-gLK
-gLK
-gLK
+jAi
+jAi
+jAi
 goP
 qFP
 tVN
@@ -60070,8 +60307,8 @@ lsO
 gcC
 eOL
 cfs
-mii
-pGY
+rFs
+dAC
 bOY
 dAC
 iIT
@@ -60279,7 +60516,7 @@ ctO
 qYP
 mds
 mhY
-qhI
+lZu
 fNo
 pCI
 teQ
@@ -60293,13 +60530,13 @@ teQ
 teQ
 teQ
 cqf
-fJH
+pbL
 ulc
 eOL
-ksk
-wkg
+mii
+pIs
 dqk
-sjX
+bOY
 dAC
 jhj
 rGn
@@ -60495,8 +60732,8 @@ toX
 pau
 nhi
 bSf
-mpm
-qhl
+lOu
+vNm
 qzS
 qZs
 oEZ
@@ -60520,20 +60757,20 @@ pho
 tMg
 rxg
 cqf
-mDS
-iXv
+pbL
+gcC
 eOL
-vGb
-fwe
-nps
-azD
+mii
+lOd
+kmf
+bOY
 bSn
 jhj
 kNZ
 cgh
 uQK
 meg
-xHL
+noE
 tJM
 uQK
 tJM
@@ -60541,7 +60778,7 @@ oZL
 tJM
 uQK
 tJM
-noE
+xHL
 feb
 xii
 vtB
@@ -60748,12 +60985,12 @@ vIJ
 mZR
 cqf
 mDS
-kVL
+ulc
 eOL
-spK
-vQy
+ksk
+wkg
 csL
-azD
+div
 sXz
 jhj
 gRC
@@ -60942,8 +61179,8 @@ qYw
 pix
 qYw
 bpA
-dnw
-ojY
+beZ
+beZ
 qYw
 hBq
 teP
@@ -60975,11 +61212,11 @@ hqg
 flR
 cqf
 mDS
+iXv
 eOL
-eOL
-nXv
-nXv
-nXv
+vGb
+fwe
+kmf
 azD
 xmV
 jhj
@@ -60991,11 +61228,11 @@ kod
 uQK
 uQK
 uQK
+tPd
+uQK
+uQK
+uQK
 kqF
-uQK
-uQK
-uQK
-xlh
 uQK
 xii
 vtB
@@ -61202,10 +61439,10 @@ teQ
 teQ
 cqf
 mDS
+kVL
 eOL
-cxy
-oIu
-pVw
+spK
+vQy
 nXv
 mXt
 sUN
@@ -61223,7 +61460,7 @@ nMO
 pYB
 xtn
 cIe
-nMO
+pSA
 xii
 vtB
 fSl
@@ -61430,27 +61667,27 @@ mdy
 cqf
 mDS
 eOL
-cxy
-rAh
-fXW
-nXv
+eOL
+pwP
+pwP
+pwP
 egx
-xfK
+pwP
 jhj
 myi
-pYB
-pYB
-jkE
-nts
-xTy
-pYB
-jkE
-nts
-xTy
-pYB
-jkE
-nts
-xTy
+vxh
+vxh
+vxh
+vxh
+vxh
+vxh
+vxh
+wqD
+rbD
+aDD
+aDD
+aDD
+mba
 xii
 vtB
 eWS
@@ -61658,25 +61895,25 @@ cqf
 mDS
 eOL
 xVe
-rAh
-xvZ
-nXv
+cIM
+jlx
+rio
 hmd
 pOC
 jhj
 mFN
-pYB
-uQK
-uQK
+xgI
+ucw
+veO
 gFF
-uQK
-uQK
-uQK
+veO
+diL
+fUa
 qwD
+ovt
 uQK
 uQK
 uQK
-eXq
 uQK
 xii
 vtB
@@ -61887,20 +62124,20 @@ eOL
 mGw
 rWr
 jlx
-nXv
+wnp
 rHl
 nYV
-jhj
-ryS
-pYB
 uQK
-tJM
-tJM
-tJM
-uQK
-tJM
-tJM
-tJM
+veO
+veO
+ggk
+vgu
+arJ
+veO
+cdF
+rsh
+qwD
+dIr
 uQK
 tJM
 tJM
@@ -62116,21 +62353,21 @@ gwU
 mUo
 ujF
 aFF
-xdx
-jhj
+rUj
+koL
 ryS
-pYB
-uQK
+vbV
 vov
+vov
+uil
+vbV
+vov
+vCK
+krl
+ipw
+bdD
+tJM
 oZL
-tJM
-uQK
-tJM
-xHL
-tJM
-uQK
-tJM
-xHL
 pYU
 xii
 vtB
@@ -62341,20 +62578,20 @@ eOL
 vsO
 xvZ
 tCb
-nXv
+hXb
 egX
-nYV
-jhj
-ryS
-pYB
-uQK
-tJM
-tJM
-tJM
-uQK
-tJM
-tJM
-tJM
+wXw
+nps
+veO
+qKp
+pjV
+veO
+veO
+veO
+veO
+veO
+qwD
+agK
 uQK
 tJM
 tJM
@@ -62567,24 +62804,24 @@ xcb
 eOL
 qYu
 vOC
-nXv
-nXv
+jlx
+qvJ
 cGy
 ruQ
-jhj
+uQK
 jyp
-avs
+sRQ
+ism
+ilN
+hvG
+uau
+veO
+veO
+qwD
+aGU
 uQK
 uQK
 uQK
-uQK
-uQK
-uQK
-uQK
-uQK
-uQK
-uQK
-jhj
 jhj
 xii
 dFF
@@ -62593,7 +62830,7 @@ pRn
 pRn
 sIw
 gxT
-iTy
+ffn
 jUl
 tJM
 tJM
@@ -62798,32 +63035,32 @@ ggG
 nEY
 pYW
 obZ
-gTB
-xhc
-iDb
-iDb
-spO
-cvW
-vIf
+vBw
+vBw
+vBw
+vBw
+vBw
+vBw
+vBw
 iDb
 dQN
 vGT
 qaB
 qKK
 aDD
-jhj
-rbD
+uso
+xbU
 hvQ
 wDi
+njG
 gBM
-rxY
-uau
-iBa
-pYB
-ffn
-jUl
-tJM
-tJM
+aZG
+uWX
+wrx
+pLW
+icY
+aYy
+rGd
 tJM
 jhj
 gBM
@@ -63024,27 +63261,27 @@ lGe
 mcY
 vFY
 qup
-iyc
+nYV
 fMY
+xhc
+dDo
 rox
-rox
-rox
-tuO
-veO
-veO
-veO
-dNM
-nYi
-veO
-veO
-krl
+kHv
+kHv
+vBw
+pGY
+nts
+xTy
+wwt
+jkE
+nts
+uYC
 jhj
 hvq
-rCW
-hJL
+gdH
+niS
 gBM
-oXw
-iBa
+owS
 iBa
 iTy
 ffn
@@ -63251,34 +63488,34 @@ pAk
 dVa
 vFY
 qup
-ipw
+nYV
 krn
 sVh
-sVh
+uTq
 scL
-sVh
-sVh
-scL
-sVh
-sYT
-nYi
-veO
-veO
+kHv
+bYT
+vBw
+uQK
+eXq
+uQK
+uQK
+uQK
 eQf
+uQK
 jhj
-kVJ
 rCW
+gdH
 hJL
 omD
 pFL
-dyc
 lEI
 aEZ
 gyo
 jUl
 aUD
 udw
-tJM
+uMV
 jhj
 dVr
 uQK
@@ -63458,9 +63695,9 @@ qbQ
 knk
 sNj
 lzm
-hvG
-hvG
-hvG
+cqf
+cqf
+cqf
 cqf
 lsG
 cqf
@@ -63477,28 +63714,28 @@ lwJ
 ivt
 rfk
 vFY
-qup
+bSj
 uLJ
 gTB
-veO
-veO
-diL
-veO
-veO
-veO
-xKv
-dNM
-nYi
-veO
-veO
-owN
+qMw
+vuk
+qXX
+kHv
+dqd
+vBw
+tJM
+tJM
+tJM
+uQK
+tJM
+tJM
+tJM
 jhj
 kXk
-rCW
-hJL
+gdH
+niS
 gBM
-fUa
-iBa
+hdi
 fGr
 iTy
 ffn
@@ -63685,7 +63922,7 @@ lgL
 knk
 sNj
 dKo
-hvG
+cqf
 bPI
 nMI
 cqf
@@ -63697,7 +63934,7 @@ cqf
 cqf
 mDS
 eOL
-ivt
+nCH
 ivt
 cOH
 gLf
@@ -63705,33 +63942,33 @@ eHB
 gsW
 tyR
 bEC
-ggq
-vCK
-qKp
-veO
-dFO
-veO
-qKp
-veO
-tbD
-sgY
-ngh
-mrQ
+nYV
+krn
+kHv
+tak
+scL
+kHv
+kHv
+jTu
+tJM
+xHL
+tJM
+uQK
+tJM
+xHL
 kPD
-win
-xbU
-wqD
+jhj
 hJj
 mLQ
+vWk
 gBM
-aZG
-wrx
-uWX
-wrx
-pLW
-icY
-aYy
-rGd
+cdl
+iBa
+pYB
+ffn
+jUl
+tJM
+tJM
 tJM
 jhj
 ogY
@@ -63913,49 +64150,49 @@ knk
 ncg
 rac
 dpp
-uil
+vlu
 khs
 cqf
 hHD
 qFY
 dwF
 vvO
-rwK
+vvO
 vvO
 mDS
 eOL
 oHs
-ivt
+oSQ
 csj
-ivt
+oSQ
 cLT
 dMa
 gbU
 hdT
-qtC
-gTB
+nYV
+fMY
 apx
 xef
-xgI
+pkv
 kHv
-sRQ
+kHv
 vBw
-ism
-iIT
-jhj
-jhj
-jhj
-jhj
-xii
+tJM
+tJM
+tJM
+uQK
+tJM
+tJM
+tJM
 xii
 xii
 vUk
 pRn
-pRn
-pRn
+gBM
+rxY
 jxb
 gxT
-iTy
+ffn
 fjc
 tJM
 tJM
@@ -64139,7 +64376,7 @@ qYw
 knk
 sNj
 viR
-hvG
+cqf
 hFG
 laC
 cqf
@@ -64163,22 +64400,22 @@ nYV
 xhQ
 wla
 wla
-wla
 rTO
 ejG
 ejG
 ejG
 ejG
-sML
-bDo
-bDo
-bDo
+ejG
+ejG
+ejG
+ejG
+ejG
 xii
-fSl
+xii
 fSl
 oZk
 pRn
-rfN
+pRn
 pRn
 pRn
 pRn
@@ -64389,9 +64626,9 @@ hdT
 vIl
 xhQ
 gmc
-oeI
+bEe
 xnr
-xhQ
+afL
 qLu
 dnJ
 ljK
@@ -64401,8 +64638,8 @@ bDo
 qpT
 bDo
 xii
-mVM
-eRi
+fSl
+fSl
 qKJ
 pRn
 gZU
@@ -64614,9 +64851,9 @@ uFk
 nYV
 hdT
 nYV
-uBq
+xhQ
 oeI
-oeI
+qtC
 ftR
 afL
 mWB
@@ -64803,7 +65040,7 @@ cyE
 qYw
 qYw
 ojY
-fXg
+lhD
 qYw
 gIP
 uMN
@@ -64830,7 +65067,7 @@ vQR
 mqz
 cqf
 mDS
-moX
+lsO
 eOL
 xuJ
 eoB
@@ -64845,7 +65082,7 @@ ocE
 fWT
 jdP
 wcd
-afL
+mEE
 sQa
 env
 nbz
@@ -65069,10 +65306,10 @@ hKG
 hdT
 nYV
 uBq
-oeI
+kMZ
 wRv
 jtR
-xhQ
+afL
 rvA
 oSt
 poB
@@ -65259,7 +65496,7 @@ qvA
 qvA
 ory
 xgU
-oef
+rqO
 oef
 oef
 qxi
@@ -65279,7 +65516,7 @@ vlu
 aze
 cqf
 wBj
-bND
+wjQ
 mXR
 fCd
 cqf
@@ -65294,12 +65531,12 @@ jsb
 tFM
 nYV
 hdT
-uvX
+nYV
 xhQ
 mmO
-oeI
-oQz
-xhQ
+nUx
+ftR
+afL
 juD
 fgC
 oKu
@@ -65524,13 +65761,13 @@ rIH
 xdx
 xhQ
 vvH
-vvH
-vvH
-xhQ
+hZr
+jLI
 afL
+oXw
 eGP
-ejG
-ejG
+wHB
+bBM
 sML
 bDo
 bDo
@@ -65733,7 +65970,7 @@ fFM
 ebX
 cqf
 coN
-bND
+wjQ
 sEo
 bPF
 cqf
@@ -65750,21 +65987,21 @@ tug
 qKN
 nYV
 qTO
-vuk
-elI
 xix
-jpj
-pIs
-vWk
-nqU
+xix
+xix
+afL
+afL
+afL
+afL
+ejG
 ejG
 ejG
 ejG
 ejG
 xii
 xii
-pRn
-pRn
+fSl
 qKJ
 pRn
 awo
@@ -65978,20 +66215,20 @@ vfL
 vcA
 qTO
 oDM
+crg
+crg
+hrl
 agj
-agj
-agj
-agj
-eBw
+elI
 tYk
+xKv
+cvW
 wmI
 vpf
 iOn
 gEc
 xii
-gRc
-cgt
-prp
+fSl
 qKJ
 pRn
 sFz
@@ -66209,17 +66446,17 @@ avt
 oOK
 rcX
 uiy
-qss
-ygS
+crg
+xYK
+xbm
+qAP
 wmI
 dZe
 dZe
 tiA
 xii
-pRn
-pRn
-pRn
-qKJ
+fSl
+cbM
 pRn
 pRn
 pRn
@@ -66438,23 +66675,23 @@ aLk
 een
 dTM
 roA
+gea
+qRp
 ydX
 dse
 pxM
 tQF
 qBA
-vbV
-wXw
 mBs
 dkV
-xii
-xii
-xii
-xii
-xii
-xii
-xii
-xii
+pRn
+pRn
+pRn
+pRn
+pRn
+pRn
+pRn
+pRn
 pRn
 pRn
 tkM
@@ -66638,7 +66875,7 @@ aNZ
 qbQ
 vaS
 cqf
-ciC
+hHD
 jFJ
 cqf
 lVG
@@ -66665,23 +66902,23 @@ wui
 iqI
 crg
 xYK
+xbm
+jCW
 wmI
 mJJ
 xbm
 dvQ
 xii
-pRn
-pRn
 iSR
 hjz
-qXX
+pRn
 qSh
 scx
-qAP
+pRn
 jIb
 uos
 xeS
-xii
+pRn
 hMX
 pRn
 wbG
@@ -66892,23 +67129,23 @@ jdU
 obH
 crg
 oBa
+cZQ
+ciC
 wmI
 bLv
 eCZ
 tBR
 xii
-qfN
-pRn
 qJW
-ciD
-hzV
+aMX
+yfe
 gvO
-noh
+eLt
 oYE
 sPL
 xyI
 wgj
-xii
+pRn
 ggx
 pRn
 xCh
@@ -67123,19 +67360,19 @@ owA
 owA
 owA
 owA
+owA
 xii
-pRn
-pRn
+xii
 qJW
 bmW
-qXX
-qMw
-mhC
-qxZ
-jIb
+pRn
+pRn
+pRn
+pRn
+uBl
 tlN
-cIM
-xii
+rfN
+pRn
 bXj
 pRn
 wbG
@@ -67320,7 +67557,7 @@ qbQ
 lCP
 pes
 rVb
-ntT
+prm
 xEa
 aTC
 xYe
@@ -67352,17 +67589,17 @@ dyH
 xjD
 pAv
 pRn
-bXc
+fSl
 vXc
 aMX
-xii
-xii
+prp
+cgt
 iKY
-xii
-xii
-xii
-xii
-xii
+pRn
+pRn
+pRn
+pRn
+pRn
 bXj
 pRn
 wbG
@@ -67543,9 +67780,9 @@ bXj
 lUP
 qDD
 sNj
-qbQ
+sNj
 wYe
-gMk
+nYi
 sDK
 qlW
 xEa
@@ -67583,9 +67820,9 @@ vtT
 nkW
 aMX
 pRn
-xii
-xii
-xii
+pRn
+pRn
+pRn
 avM
 hMX
 hMX
@@ -67803,8 +68040,8 @@ owA
 qDM
 fxt
 fxt
-fxt
-qDM
+sqg
+iqM
 pRn
 nxC
 qJW
@@ -68210,8 +68447,8 @@ bfn
 beZ
 lVt
 rAI
-gdH
-qvA
+rAI
+rAI
 qvA
 lxO
 sSQ
@@ -68484,7 +68721,7 @@ lFd
 hsF
 jEi
 uEm
-jEi
+bDt
 woR
 hlU
 svd
@@ -68711,7 +68948,7 @@ bBq
 qjK
 htU
 htU
-kNB
+eRi
 uog
 myk
 htU
@@ -69164,7 +69401,7 @@ qap
 agG
 oXI
 kEN
-nzJ
+fXW
 rnl
 oTV
 qIb
@@ -70552,7 +70789,7 @@ osd
 mha
 jQx
 vdl
-roe
+rsw
 gEs
 wfP
 axm
@@ -70958,9 +71195,9 @@ aGz
 rOm
 nqq
 mwT
-rAn
+mwT
 lSX
-qUy
+mwT
 pzT
 oiY
 iCG
@@ -71006,7 +71243,7 @@ unE
 mha
 jQx
 vdl
-roe
+rsw
 gEs
 dop
 axm
@@ -71391,7 +71628,7 @@ okX
 arz
 qsQ
 sSQ
-ssO
+fjr
 xAz
 jiT
 dwh
@@ -71399,8 +71636,8 @@ dNB
 twM
 fOv
 qMo
-sBf
-bwC
+oQz
+jph
 lRW
 jQB
 vBH
@@ -71908,7 +72145,7 @@ pdh
 kuE
 qtq
 mEB
-niS
+dET
 eIG
 dzD
 qtq
@@ -72519,7 +72756,7 @@ aAh
 mCf
 mDV
 bQB
-eTN
+pph
 bmY
 oKV
 oKV
@@ -72598,9 +72835,9 @@ tAF
 mRH
 lYQ
 ghL
-usc
-usc
-usc
+hAN
+fgc
+wfQ
 icA
 iDG
 cLw
@@ -72771,7 +73008,7 @@ myE
 uLf
 amJ
 rLT
-wnp
+myE
 sJv
 vrQ
 tVp
@@ -72816,7 +73053,7 @@ pdh
 dKh
 qtq
 bZn
-bEV
+dET
 qMl
 tTM
 gko
@@ -73156,13 +73393,13 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
+mVM
+mVM
+mVM
+mVM
+mVM
+mVM
 bXj
 bXj
 bXj
@@ -73384,11 +73621,11 @@ bXj
 bXj
 bXj
 bXj
+ggx
 bXj
+mbG
 bXj
-bXj
-bXj
-bXj
+ggx
 bXj
 bXj
 bXj
@@ -73505,11 +73742,11 @@ oki
 oHS
 uFd
 uFd
-ghL
+xdX
 usc
-usc
+ldE
 kVG
-usc
+ogI
 lzE
 uCC
 qqg
@@ -73609,15 +73846,15 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+kFI
+kFI
+kFI
+kFI
+kFI
+kFI
+kFI
+kFI
+kFI
 bXj
 bXj
 bXj
@@ -73728,10 +73965,10 @@ gqW
 xaq
 xCJ
 gko
-uFd
-uFd
-uFd
-uFd
+noh
+noh
+noh
+noh
 ghL
 fIZ
 fIZ
@@ -73835,17 +74072,17 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+kFI
+kFI
+mrQ
+bXc
+bXc
+rwK
+hQI
+bXc
+mrQ
+kFI
+kFI
 bXj
 bXj
 bXj
@@ -73955,16 +74192,16 @@ bxo
 aol
 fnB
 gko
-oVU
+fFY
 eeQ
-nkK
-wDk
+muQ
+mAJ
 ghL
 tcx
 bnf
 gsz
 fOP
-ubC
+alQ
 uCC
 qqn
 ghL
@@ -74060,21 +74297,21 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
+kFI
+bXc
+diW
+diW
+diW
+diW
+diW
+diW
+diW
+bXc
+kFI
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
 bXj
 bXj
 bXj
@@ -74191,7 +74428,7 @@ tcx
 oks
 gsz
 usc
-ubC
+alQ
 ekN
 usc
 ghL
@@ -74287,21 +74524,21 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
+ggx
+kFI
+kan
+diW
+kFI
+kFI
+kFI
+kFI
+kFI
+diW
+kan
+kFI
+ggx
+mVM
 bXj
 bXj
 bXj
@@ -74418,7 +74655,7 @@ wbT
 oms
 emc
 coY
-ubC
+alQ
 fFn
 gix
 tZW
@@ -74514,21 +74751,21 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
+kFI
+vID
+ssO
+kFI
+ubm
+pVw
+dFO
+kFI
+fss
+rdk
+kFI
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
 bXj
 bXj
 bXj
@@ -74741,21 +74978,21 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
+kFI
+mrQ
+bHX
+poS
+lvh
+iNH
+gHu
+hsV
+fXg
+mrQ
+kFI
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
 bXj
 bXj
 bXj
@@ -74789,7 +75026,7 @@ mbW
 pMx
 tGa
 tGa
-koC
+gng
 tGa
 jEw
 aCQ
@@ -74968,21 +75205,21 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
+ojr
+kFI
+eBw
+nhk
+kFI
+kFI
+iJE
+kFI
+kFI
+voq
+vJv
+kFI
+dNM
+mVM
 bXj
 bXj
 bXj
@@ -75195,21 +75432,21 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
+ggx
+kFI
+bXc
+fzf
+kFI
+kFI
+kFI
+kFI
+kFI
+ciD
+bXc
+kFI
+ggx
+mVM
 bXj
 bXj
 bXj
@@ -75247,7 +75484,7 @@ avr
 fwG
 kzz
 hXj
-hXj
+nkK
 hXj
 vkn
 hXj
@@ -75422,21 +75659,21 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
+kFI
+bXc
+fzf
+fzf
+uZw
+dtM
+edL
+tbD
+ciD
+bXc
+kFI
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
 bXj
 bXj
 bXj
@@ -75649,19 +75886,19 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+kFI
+kFI
+mrQ
+bXc
+ggq
+fzf
+bXc
+bXc
+mrQ
+kFI
+kFI
 bXj
 bXj
 bXj
@@ -75689,7 +75926,7 @@ ykm
 mrj
 peP
 ehx
-rUj
+guc
 pMO
 pMO
 pMO
@@ -75876,20 +76113,20 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+kFI
+kFI
+kFI
+kFI
+fRq
+kFI
+kFI
+kFI
+kFI
+kFI
+pRG
 bXj
 bXj
 bXj
@@ -75916,7 +76153,7 @@ pMO
 sCw
 kmp
 xZl
-dfG
+lIm
 wIk
 wIk
 wIk
@@ -76103,31 +76340,31 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-tGa
-tGa
-tGa
+pyy
+cZx
 fxq
+oIu
+dyc
+hQp
+gqV
+pyy
+cxM
+pyy
+mhC
+bXj
+bXj
+bXj
+bXj
+bXj
+bXj
+wMU
+tGa
+tGa
+tGa
+iSG
 iSG
 iSG
 cJt
@@ -76204,7 +76441,7 @@ uXo
 fVT
 fVT
 fVT
-qbD
+wce
 tJb
 qEU
 iGK
@@ -76330,29 +76567,29 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-erU
-bXj
-bXj
-bXj
-vgu
+mVM
+ggx
+ggx
+pyy
+iyc
+moX
+vIf
+dqh
+sgY
+qXt
+tuO
+qXt
+jpj
+mhC
+wMU
+wMU
+wMU
+wMU
+wMU
+wMU
+wMU
 bbx
-uka
+eTN
 mqo
 iSG
 iSG
@@ -76557,28 +76794,28 @@ bXj
 bXj
 bXj
 bXj
+mVM
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-tGa
+pyy
+bxy
+emp
+ezj
+kAA
+wDk
+gdy
+pyy
+uvX
+jME
+owN
+erU
+erU
+erU
+erU
+erU
+erU
+owN
+nqU
 aDK
 tGa
 tkl
@@ -76787,16 +77024,16 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+pyy
+pyy
+pyy
+pyy
+pyy
+pyy
+pyy
+pyy
+pyy
+pyy
 bXj
 bXj
 bXj
@@ -76878,7 +77115,7 @@ fVT
 fVT
 fVT
 fJu
-lLE
+wce
 bCZ
 fVT
 fVT
@@ -76903,7 +77140,7 @@ djP
 inx
 uNI
 cLg
-arJ
+sXb
 ghL
 qVh
 lZG
@@ -77016,12 +77253,12 @@ bXj
 bXj
 bXj
 bXj
+ggx
+bXj
+lsD
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
+ggx
 bXj
 bXj
 bXj
@@ -77035,8 +77272,8 @@ bXj
 ggx
 ggx
 tGa
-iSG
-iSG
+uka
+rAn
 tGa
 gqk
 bss
@@ -77055,7 +77292,7 @@ dfG
 bfW
 uDR
 bfW
-ezl
+pzm
 qHm
 wKa
 uAv
@@ -77242,14 +77479,14 @@ bXj
 bXj
 bXj
 bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+mVM
+mVM
+mVM
+mVM
+mVM
+mVM
+mVM
+mVM
 bXj
 bXj
 bXj
@@ -77488,9 +77725,9 @@ bXj
 bXj
 bXj
 bXj
-wMU
-wMU
-wMU
+bXj
+wqu
+bXj
 qZe
 iSG
 eGA
@@ -77509,7 +77746,7 @@ ykm
 soP
 ykm
 ykm
-ykm
+ydq
 tGa
 wYh
 eaX
@@ -77521,7 +77758,7 @@ nmT
 kEh
 mWi
 fBR
-eVM
+qfN
 rNG
 tbY
 asH
@@ -77741,7 +77978,7 @@ tGa
 cPR
 woI
 qME
-ovt
+iSG
 tGa
 vux
 uSH
@@ -77957,7 +78194,7 @@ iSG
 tGa
 vhr
 tGa
-qXt
+iSG
 tGa
 iSG
 vhr
@@ -78013,7 +78250,7 @@ xkx
 xTD
 kKX
 vJR
-qqD
+doc
 aHa
 ygV
 rGC
@@ -78184,7 +78421,7 @@ rUJ
 tGa
 iSG
 hbO
-jhZ
+iSG
 iSG
 iSG
 iSG
@@ -78397,7 +78634,7 @@ bXj
 bXj
 bXj
 bXj
-bXj
+hRR
 bXj
 bXj
 bXj
@@ -78887,12 +79124,12 @@ jUt
 jDM
 hRs
 ffX
-wHB
-wHB
-wHB
+bmP
+bmP
+bmP
 wGa
 eEf
-wHB
+bmP
 lZm
 jDM
 tXj
@@ -79147,7 +79384,7 @@ wZs
 pAc
 mqb
 pAc
-pAc
+avs
 hVG
 hVG
 eZi
@@ -79338,14 +79575,14 @@ ujG
 ujG
 cil
 jUt
-stV
-poS
+jDM
+hRs
 xJE
 qlI
-jTu
+bmP
 opl
 opl
-jTu
+bmP
 hzp
 xJE
 jDM
@@ -79374,10 +79611,10 @@ ees
 pAc
 qSg
 tjX
-tjX
+rOE
 pHb
 arr
-qZR
+lAx
 qtJ
 hVG
 ewG
@@ -79557,15 +79794,15 @@ qZe
 uDA
 iSG
 xUX
-jhZ
+iSG
 lUg
 bGf
 jIo
 uJS
 xgM
-mNQ
+ujG
 ocD
-fRq
+jDM
 lot
 xJE
 tpX
@@ -79790,9 +80027,9 @@ edF
 sTp
 uPS
 rPt
-mNQ
+ujG
 eee
-fRq
+jDM
 mNS
 lYg
 olc
@@ -80019,8 +80256,8 @@ mbV
 fNl
 xmF
 mgo
-rdk
-qvJ
+mgo
+hRs
 xJE
 enz
 wnS
@@ -80242,9 +80479,9 @@ iSG
 tGa
 cWp
 tyZ
-uYC
+tyZ
 fii
-div
+aDj
 nol
 hys
 jWo
@@ -80467,12 +80704,12 @@ xEi
 xcU
 vhr
 tGa
-mNQ
-mNQ
-mNQ
-mNQ
-mNQ
-jUt
+ujG
+ujG
+ujG
+ujG
+ujG
+wuw
 jDM
 qlP
 ojp
@@ -80499,7 +80736,7 @@ gyi
 qOo
 pRy
 pRy
-pRy
+tCg
 tlL
 rlK
 jfz
@@ -81158,10 +81395,10 @@ bUY
 yap
 slB
 ivQ
-fJm
-fJm
-fJm
-fJm
+xon
+xon
+aRV
+xon
 fJm
 fwa
 xgh
@@ -81191,7 +81428,7 @@ cVS
 jLo
 jLo
 jLo
-jLo
+bVL
 hVG
 bkj
 omI
@@ -81385,11 +81622,11 @@ jDM
 awt
 xon
 tuP
-fJm
-rsw
-ubm
+xon
+nVI
+eFt
 tPU
-fAd
+fJm
 fAd
 nNo
 fAd
@@ -81612,9 +81849,9 @@ hgM
 uPF
 xon
 ivQ
-fJm
-alQ
-viz
+xon
+jqv
+eFt
 lSQ
 gdf
 arR
@@ -81839,15 +82076,15 @@ wSp
 izI
 xon
 ivQ
+xon
+xon
+rZu
+eBt
 fJm
-uZw
-edL
-bSj
-fAd
 hVM
 eSD
 wLG
-lOu
+yeg
 wLG
 hGR
 wLG
@@ -82066,8 +82303,8 @@ nZt
 tpO
 xon
 ivQ
-fJm
-fJm
+rZu
+xon
 fJm
 fJm
 fJm
@@ -82076,7 +82313,7 @@ eSD
 jvD
 uqm
 iZD
-hGR
+bpi
 wLG
 xEQ
 fAd
@@ -82293,17 +82530,17 @@ nZt
 lga
 xon
 rax
-xon
-nVI
-eFt
+rZu
+mUc
+fJm
 xVT
 mst
-lMk
-qDU
 wLG
+qDU
+dHw
 rgI
 wLG
-hGR
+yeg
 rqD
 scf
 fAd
@@ -82326,9 +82563,9 @@ fAY
 ube
 hVG
 mOY
-hrl
+qtX
 azy
-hrl
+qtX
 fkv
 hVG
 hVG
@@ -82502,7 +82739,7 @@ wge
 gRV
 wXy
 jKZ
-qwG
+vbk
 psc
 xon
 jPY
@@ -82520,15 +82757,15 @@ uRo
 yjI
 xon
 gXK
-xon
-jqv
-eFt
-jOj
+jKz
+rZu
 fJm
+jOj
+wVw
 sgp
-kSd
+sYT
 fVU
-yeg
+jhZ
 fWv
 kSd
 kcc
@@ -82553,9 +82790,9 @@ rbp
 iIV
 kMk
 xpr
-qZR
+lAx
 xnc
-qZR
+lAx
 lAx
 hVG
 wqn
@@ -82747,17 +82984,17 @@ vUg
 lVR
 xon
 ivQ
-xon
-eBt
+rZu
 rZu
 fJm
 fJm
-rqO
-bYT
-bBM
-fzf
-pkv
-eud
+fJm
+fJm
+fJm
+fJm
+fJm
+fJm
+fJm
 fJm
 fJm
 fJm
@@ -82974,18 +83211,18 @@ udi
 udD
 xon
 ivQ
+pLD
+nVw
+rZu
+ejd
+rZu
+hyu
+wbO
+hyu
+hyu
+rZu
+eCW
 xon
-xon
-aRV
-fJm
-bVL
-fvt
-kFI
-kcx
-fAd
-lff
-lOu
-fJm
 gWm
 oBJ
 xon
@@ -83201,20 +83438,20 @@ uMo
 hws
 xon
 ivQ
-rZu
-hyu
-ejd
-fJm
-lFN
-rio
-rsh
+lMk
+vKA
+nEw
+cmo
+wed
+wed
+wed
 etJ
-fAd
-tCa
-ojr
-fJm
-nVw
-hyu
+wed
+lNA
+wed
+eGJ
+qLX
+ogV
 xon
 jwL
 bfH
@@ -83428,18 +83665,18 @@ xon
 xon
 xon
 ivQ
-jKz
-pLD
-rZu
-fJm
-hXb
-hXb
-nEw
-nCH
-fJm
-fJm
-fJm
-fJm
+stV
+xon
+xon
+xon
+xon
+xon
+xon
+xon
+xon
+xon
+xon
+xon
 gTs
 wed
 aTU
@@ -83655,19 +83892,19 @@ kfX
 kfX
 kfX
 viI
-wed
-aHM
+nDx
+xon
 tVI
-fJm
+koC
 kcx
 fVL
 sgW
 lFN
-fJm
+spO
 jgJ
-wed
-eGJ
-vJv
+azg
+xon
+lbb
 rZu
 xon
 mlg
@@ -83880,24 +84117,24 @@ pnl
 dCg
 ouu
 dCg
-oea
+dCg
 lmB
 xon
-vbk
+xon
 teD
-fJm
-fJm
-fJm
-fJm
-fJm
-fJm
+epd
+sjX
+qZR
+sgW
+ngh
+qMb
 gUI
-rZu
+sHt
 xon
 xon
 xon
 xon
-jrr
+qbD
 bfH
 iaW
 urt
@@ -84108,19 +84345,19 @@ wxC
 rZu
 xon
 nMz
-jCW
+heM
 xon
-pmD
-cmo
-wed
-wed
-wed
-lNA
-wed
-lNA
+wsA
+uxo
+xBA
+qxZ
+asf
+sgW
+qUy
+xYA
 mMx
-lbb
-xon
+kNB
+sgW
 eKt
 pPM
 eoi
@@ -84339,15 +84576,15 @@ iWp
 xon
 mVg
 jpo
-ejd
-rZu
-hyu
-wbO
-hyu
-hyu
-rZu
-eCW
-xon
+qwG
+rAh
+kVJ
+sgW
+cxy
+mgO
+kOE
+ygS
+sgW
 gbf
 tRq
 mrd
@@ -84562,19 +84799,19 @@ sbH
 gIp
 uKA
 eCT
-dFD
-xon
-xon
-xon
-xon
-xon
-xon
-xon
-xon
-xon
-xon
-xon
-xon
+fvt
+qwM
+dqe
+dqe
+dqe
+win
+sjD
+sgW
+sgW
+sgW
+dnw
+sgW
+sgW
 mrd
 mrd
 mrd
@@ -84588,8 +84825,8 @@ daY
 pwn
 eSF
 vMK
-uRs
-sbY
+iAn
+mzJ
 hVG
 hty
 ewG
@@ -84794,9 +85031,9 @@ drA
 qcd
 qQV
 aVz
+xrY
 aVz
 lcR
-aVz
 iBu
 trn
 qwZ
@@ -85016,12 +85253,12 @@ uBo
 gNr
 dmj
 dSf
-epo
-epo
+unw
+unw
 eNO
 oyl
-cyL
-cyL
+hjX
+hjX
 cyL
 cyL
 cyL
@@ -85268,7 +85505,7 @@ fXi
 wXp
 tQb
 gKt
-tQb
+oVU
 waR
 auj
 bXj
@@ -86160,8 +86397,8 @@ dSi
 pSn
 ckY
 nfp
-aWc
-hZm
+viz
+lLD
 hZm
 kuk
 qCx
@@ -86176,7 +86413,7 @@ fXi
 tzx
 tQb
 tQb
-vKA
+tQb
 doe
 fXi
 qOv
@@ -86400,8 +86637,8 @@ wWM
 fXi
 ufN
 nlX
-diW
-diW
+rNB
+rNB
 hnW
 rNB
 txB
@@ -86604,7 +86841,7 @@ aWw
 tqk
 aIW
 dmj
-dmj
+mNQ
 ydH
 dmj
 beS
@@ -86613,8 +86850,8 @@ qWe
 tGN
 aXU
 nZP
-kQH
-dKq
+nfp
+eoM
 bNj
 bQD
 sfC
@@ -86625,7 +86862,7 @@ las
 bfH
 jEe
 fXi
-mzJ
+aLO
 qHT
 lpm
 fcn
@@ -87065,7 +87302,7 @@ rFN
 dHn
 nKA
 uST
-njG
+egg
 emG
 uST
 hJp
@@ -87086,7 +87323,7 @@ ewG
 qhZ
 tLI
 tLI
-aGU
+tLI
 tLI
 liQ
 jIQ
@@ -87538,7 +87775,7 @@ hVG
 hVG
 hVG
 hVG
-oof
+xlh
 oof
 hVG
 hVG
@@ -87735,10 +87972,10 @@ bXj
 bXj
 bXj
 ggx
-wYi
-iqM
-bxy
-mUc
+ggx
+bXj
+bXj
+bXj
 wYi
 brt
 wrr
@@ -87962,10 +88199,10 @@ bXj
 bXj
 bXj
 bXj
-wYi
-hRR
-voq
-dqh
+ggx
+ggx
+bXj
+bXj
 wYi
 kYD
 iar
@@ -87977,7 +88214,7 @@ rBi
 hmJ
 pFV
 iOu
-uMV
+txl
 iOu
 bNu
 uiJ
@@ -88189,21 +88426,21 @@ bXj
 bXj
 bXj
 bXj
-wYi
-uKU
-dIr
-iJE
+bXj
+bXj
+bXj
+bXj
 wYi
 kYD
 hWI
 eBb
 fML
-pdo
+lLE
 eBG
 ehm
 sbl
 cNv
-pbC
+bEV
 rBi
 cNv
 pbC
@@ -88416,10 +88653,10 @@ bXj
 bXj
 bXj
 bXj
-wYi
-ilN
-hZr
-lsD
+bXj
+bXj
+bXj
+bXj
 wYi
 wYi
 wYi
@@ -88429,8 +88666,8 @@ wYi
 uST
 uST
 bGZ
-cNv
-cdF
+bJx
+qwA
 uST
 uST
 uST
@@ -88643,28 +88880,28 @@ bXj
 bXj
 bXj
 bXj
-jLI
-tPd
-tak
-wsA
-vxh
-pRG
-kOE
-fLM
-vNm
-pyy
-txl
-mEE
-qxg
-bJx
-qwA
+bXj
+bXj
+bXj
+bXj
+bXj
+bXj
+bXj
+ggx
+bXj
+bXj
+bXj
 uST
-uxo
+qxg
+fLM
+cNv
+uST
+mRM
 aNp
 pTy
 ofu
-pjV
-sHt
+fCo
+lwZ
 vtD
 ubH
 ubH
@@ -88870,23 +89107,23 @@ bXj
 bXj
 bXj
 bXj
-jLI
-gqV
-mbG
-koL
-wYi
-wYi
-dqe
-sjD
-dqe
-epd
-sjD
-dqe
-hgf
-cNv
-cNv
+bXj
+bXj
+bXj
+bXj
+bXj
+bXj
+ggx
+ggx
+bXj
+bXj
+bXj
 uST
-mRM
+srk
+cTq
+rBi
+uST
+oyq
 kea
 fCo
 wWS
@@ -89097,23 +89334,23 @@ bXj
 bXj
 bXj
 bXj
-jLI
-jLI
-jLI
-wYi
-wYi
+bXj
+bXj
+bXj
+bXj
+bXj
 ggx
-dqe
-xdX
-fss
-qRp
-dqd
-dqe
-srk
-cTq
-rBi
+ggx
+ggx
+ggx
+ggx
+ggx
 uST
-oyq
+qDW
+eqt
+rVl
+uST
+uPE
 kea
 fCo
 dPQ
@@ -89328,20 +89565,20 @@ bXj
 bXj
 bXj
 bXj
+bXj
 ggx
+bXj
 ggx
-dqe
-wjQ
-aLO
-cZQ
-unw
-dqe
-qDW
-eqt
-rVl
+bXj
+bXj
+bXj
 uST
-uPE
-kea
+uST
+uST
+uST
+uST
+mYn
+mYn
 fCo
 fCo
 fCo
@@ -89554,20 +89791,20 @@ bXj
 bXj
 bXj
 bXj
+bXj
+bXj
 ggx
+bXj
 ggx
+bXj
+bXj
+bXj
 ggx
-dqe
-cdl
-nwh
-bHX
-dqe
-dqe
-uST
-uST
-uST
-uST
+bXj
 mYn
+nwh
+upq
+eud
 mYn
 ajN
 wWS
@@ -89781,20 +90018,20 @@ bXj
 bXj
 bXj
 bXj
-ggx
+bXj
+bXj
+bXj
 bXj
 ggx
-dqe
-ogI
-mgO
-cxM
-dqe
+bXj
+bXj
+bXj
 ggx
 ggx
 mYn
-ldE
-upq
-bDt
+xQg
+fCo
+fCo
 dSk
 grz
 dPQ
@@ -90008,20 +90245,20 @@ bXj
 bXj
 bXj
 bXj
-ggx
+bXj
+bXj
+bXj
 bXj
 ggx
-dqe
-sjD
-sjD
-sjD
-dqe
+bXj
+bXj
+bXj
 ggx
 bXj
 mYn
 pia
 wzq
-jgd
+nBM
 wDN
 qlR
 nBM
@@ -90237,7 +90474,7 @@ bXj
 bXj
 bXj
 bXj
-ggx
+bXj
 bXj
 bXj
 bXj
@@ -90248,7 +90485,7 @@ bXj
 dSk
 xQg
 ilM
-wVw
+fCo
 dSk
 grz
 fCo
@@ -90464,7 +90701,7 @@ bXj
 bXj
 bXj
 bXj
-ggx
+bXj
 bXj
 bXj
 bXj
@@ -90473,7 +90710,7 @@ bXj
 ggx
 bXj
 dSk
-xQg
+dSk
 fub
 qwp
 dSk
@@ -90699,7 +90936,7 @@ bXj
 bXj
 bXj
 bXj
-dSk
+bXj
 dSk
 dSk
 jWq

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -262,7 +262,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "agj" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
 "agG" = (
@@ -278,21 +278,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"agK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
 "agL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -451,12 +436,16 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "alQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "amc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -669,9 +658,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "arJ" = (
-/obj/machinery/monkey_recycler,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "arR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -703,10 +691,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
-"asf" = (
-/obj/machinery/byteforge,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
 "asu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -819,10 +803,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "avs" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar)
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "avt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -922,6 +909,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"awv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "awY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
@@ -999,12 +993,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"azg" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
 "azk" = (
 /obj/machinery/requests_console{
 	department = "Head of Security's Desk";
@@ -1286,17 +1274,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/ai_slipper{
+	uses = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "aGV" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
@@ -1313,6 +1295,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/theater)
+"aHo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "aHv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -1445,10 +1433,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "aLO" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/effect/turf_decal/siding/brown,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "aLP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -1486,6 +1476,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"aMQ" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "aMS" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/carpet/royalblue,
@@ -2066,13 +2060,6 @@
 /obj/effect/spawner/atmos_canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
-"bdD" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #4";
-	req_access = list("xenobiology")
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "bdN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Mix"
@@ -2427,18 +2414,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"bpi" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "bpq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2516,6 +2491,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"bsS" = (
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat External Port";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "bto" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -2668,9 +2650,25 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
 "bxy" = (
-/obj/machinery/computer/monitor,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom"
+	},
+/obj/item/radio/intercom/directional/north{
+	frequency = 1447;
+	name = "Private Channel";
+	freerange = 1
+	},
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bxC" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -2822,9 +2820,12 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
 "bBM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "bCt" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2902,16 +2903,11 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "bDt" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "bDB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -2953,10 +2949,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
-"bEe" = (
-/obj/machinery/module_duplicator,
-/turf/open/floor/circuit,
-/area/station/science/circuits)
 "bEC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2990,10 +2982,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bEV" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/item/trash/can,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat Chamber Foyer";
+	network = list("minisat")
+	},
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "bEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -3151,15 +3147,12 @@
 /turf/open/floor/iron/white,
 /area/station/security/brig)
 "bHX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "bHY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -3414,6 +3407,12 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/warden)
+"bPA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bPF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -3521,6 +3520,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"bRZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "bSa" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
@@ -3547,19 +3553,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bSj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/structure/table,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science{
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/turf/open/floor/iron,
+/area/station/science/explab)
 "bSn" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -3683,13 +3683,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bVL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen)
+/obj/machinery/light/directional/west,
+/obj/machinery/power/smes/super/full,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bVX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -3740,8 +3738,12 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bXc" = (
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "bXj" = (
 /turf/open/space/basic,
 /area/space)
@@ -3803,9 +3805,17 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "bYT" = (
-/obj/structure/sign/poster/official/safety_report/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/obj/machinery/light/floor{
+	brightness = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "bZn" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
@@ -3882,20 +3892,6 @@
 /obj/machinery/air_sensor/air_tank,
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
-"cbM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "ccj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -3910,6 +3906,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"ccK" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "cdc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/east,
@@ -3921,10 +3930,10 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit)
 "cdl" = (
-/obj/structure/table,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cdE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3937,9 +3946,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cdF" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "cdI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4044,21 +4055,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ciC" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/newscaster/directional/south,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+"ciD" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"ciD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "ciG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -4452,6 +4458,7 @@
 "csL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "csY" = (
@@ -4539,15 +4546,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cvW" = (
-/obj/structure/table,
-/obj/item/mmi,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/ecto_sniffer{
-	pixel_x = -6;
-	pixel_y = 6
-	},
+/obj/machinery/vending/cola/black,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "cwj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -4587,15 +4588,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cxy" = (
-/obj/machinery/computer/exoscanner_control,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
+/obj/machinery/door/poddoor/shutters{
+	id = "stationawaygate";
+	name = "Gateway Access Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/gateway)
 "cxM" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/vacuum/directional/south,
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cxO" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Bee Containment";
@@ -4629,6 +4633,20 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"cyR" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "cyV" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -5472,19 +5490,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"cZx" = (
-/obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "cZI" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "cZQ" = (
-/obj/machinery/computer/mechpad{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/machinery/computer/exodrone_control_console,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "dam" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -5745,12 +5758,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "div" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/obj/machinery/light/directional/north,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "diC" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
@@ -5764,8 +5774,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "diW" = (
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/bed/dogbed{
+	name = "Bobbernaut's Beb"
+	},
+/mob/living/basic/slime/pet{
+	slime_type = /datum/slime_type/purple;
+	desc = "The Science Divisions pet slime. Isn't it adorable when it bobbles around?";
+	name = "Bobbernaut"
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/command/heads_quarters/rd)
 "dja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5938,17 +5956,14 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "dnw" = (
-/obj/machinery/door/airlock/mining{
-	name = "Drone Bay"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs/old{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/area/station/cargo/drone_bay)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "dnJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5969,12 +5984,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"doc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/theater)
 "doe" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/computer/security/mining{
@@ -6061,23 +6070,24 @@
 /turf/open/floor/carpet/green,
 /area/station/service/theater)
 "dqd" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "dqe" = (
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
 "dqh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","qm")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/mob/living/simple_animal/bot/secbot/pingsky,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "dqk" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
@@ -6177,21 +6187,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
-"dtM" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "dtQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -6344,21 +6339,21 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "dyc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "dye" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/royalblack,
 /area/station/commons/dorms)
+"dyg" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "dyD" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/mapping_helpers/broken_floor,
@@ -6512,19 +6507,6 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"dDo" = (
-/obj/structure/table/glass,
-/obj/item/biopsy_tool{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/book/manual/wiki/cytology{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
 "dEn" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
@@ -6618,23 +6600,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "dFO" = (
-/obj/machinery/turretid{
-	control_area = "/area/station/ai_monitored/turret_protected/ai";
-	name = "AI Chamber turret control";
-	pixel_x = 5;
-	pixel_y = -24
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/newscaster/directional/west,
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "MiniSat AI Chamber Core";
-	network = list("minisat")
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "dFR" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -6660,6 +6635,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"dGo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "dGx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -6708,18 +6689,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"dHw" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
 "dHz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/east{
@@ -6792,12 +6761,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dIr" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "dIs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6949,12 +6918,14 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "dNM" = (
-/obj/machinery/camera/motion/directional/north{
-	network = list("minisat");
-	c_tag = "MiniSat External Aft"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "dNP" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker/impressa,
@@ -7262,7 +7233,7 @@
 "dVr" = (
 /obj/item/gift/anything,
 /turf/open/floor/plating,
-/area/station/science/xenobiology)
+/area/station/maintenance/port/aft)
 "dVt" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
@@ -7539,15 +7510,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "edL" = (
-/obj/machinery/status_display/ai/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/research)
 "edO" = (
 /obj/structure/table,
 /obj/item/storage/box/rxglasses{
@@ -8003,10 +7968,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"emp" = (
-/obj/machinery/digital_clock/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "emG" = (
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
@@ -8093,14 +8054,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"eoM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
 "eoU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8110,14 +8063,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "epd" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat External Starboard";
+	network = list("minisat")
 	},
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/turf/open/space/basic,
+/area/space)
 "epo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8194,9 +8145,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "erU" = (
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/door/poddoor/shutters{
+	id = "aux_base_shutters";
+	name = "Auxillary Base Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "eso" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/light/directional/west,
@@ -8273,11 +8228,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eud" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "euv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -8472,16 +8426,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"ezj" = (
-/obj/item/radio/intercom/directional/east{
-	broadcasting = 1;
-	listening = 0;
-	frequency = 1447
-	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "ezk" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lantern{
@@ -8544,9 +8488,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eBw" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "eBE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -9171,9 +9121,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "eTN" = (
-/obj/effect/landmark/navigate_destination/minisat_access_ai,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "eTU" = (
 /turf/closed/wall,
 /area/station/commons/toilet)
@@ -9323,6 +9276,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
+"eYi" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "eYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -9453,6 +9412,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
+"fcq" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "fcx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -9551,6 +9519,13 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"feG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "feH" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -9616,11 +9591,6 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/central)
-"fgc" = (
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "fgi" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -9739,7 +9709,7 @@
 	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Xeno Test Chamber Interior";
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -9958,6 +9928,12 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
+"fpR" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "fqW" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/iron,
@@ -10023,10 +9999,20 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/science/xenobiology)
 "fsQ" = (
 /turf/open/floor/carpet/red,
 /area/station/service/lawoffice)
+"ftm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/window/right/directional/south{
+	name = "Xenobiology Desk";
+	req_access = list("xenobiology")
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/plating,
+/area/station/science/research)
 "ftA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -10083,12 +10069,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "fvt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "fvE" = (
 /obj/machinery/power/apc/auto_name/directional/east{
 	areastring = "/area/station/security/prison"
@@ -10209,11 +10192,11 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "fxq" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air Out"
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "fxt" = (
 /turf/open/floor/circuit,
 /area/station/science/robotics/mechbay)
@@ -10309,15 +10292,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fzf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 14
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 10;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "fzg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10889,18 +10875,8 @@
 /area/station/hallway/primary/central)
 "fRq" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Chamber"
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit,
+/area/station/science/robotics/mechbay)
 "fRz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10978,12 +10954,14 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain)
 "fUa" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/ai_monitored/turret_protected/ai)
 "fUe" = (
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
 /turf/open/floor/iron,
@@ -11106,14 +11084,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "fXg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/table,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "fXi" = (
 /turf/closed/wall,
 /area/station/cargo/miningdock)
@@ -11153,9 +11129,8 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "fXW" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "fXY" = (
 /obj/machinery/computer/atmos_control/nitrous_tank{
 	dir = 4
@@ -11226,6 +11201,11 @@
 /obj/item/bedsheet/red,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"gaj" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "gat" = (
 /obj/machinery/vending/cola,
 /obj/effect/turf_decal/stripes/line{
@@ -11340,10 +11320,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"gdy" = (
-/obj/machinery/vending/cola/black,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "gdG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -11353,16 +11329,9 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "gdH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/landmark/navigate_destination/minisat_access_ai,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/lesser)
 "gdO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/air_sensor/incinerator_tank,
@@ -11371,10 +11340,6 @@
 "gdX" = (
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"gea" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "get" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -11418,19 +11383,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"ggk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "ggq" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "MiniSat Chamber Starboard";
-	network = list("minisat")
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "ggx" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -11815,10 +11774,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "gqV" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "gqW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
@@ -12276,6 +12236,11 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"gAi" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/trash/can,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "gAl" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -12518,10 +12483,6 @@
 /obj/item/storage/box/firingpins,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"gHu" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "gHB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -12804,10 +12765,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "gRc" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/machinery/byteforge,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "gRz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12883,6 +12843,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
+"gSo" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "gSp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13215,6 +13182,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hcg" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/kitchen)
 "hct" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -13238,12 +13211,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "hdi" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "hdR" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -13394,6 +13366,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/cyan,
 /area/station/service/library)
+"hhU" = (
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #4";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "hid" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Waste In"
@@ -13460,16 +13439,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"hjX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "hke" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -13509,9 +13478,10 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/nuke_storage)
 "hlK" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/machinery/quantum_server,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "hlU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -13760,9 +13730,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "hrl" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/robotics/lab)
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "hrJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13819,13 +13789,6 @@
 /obj/effect/spawner/atmos_canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"hsV" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "hta" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -14177,11 +14140,9 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "hzV" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/machinery/monkey_recycler,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "hAA" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
@@ -14200,10 +14161,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
-"hAN" = (
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "hAP" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
@@ -14428,11 +14385,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hHD" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "hIf" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -14558,6 +14518,17 @@
 "hLY" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"hMy" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "hMM" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/stripes/line{
@@ -14689,6 +14660,11 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"hPH" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "hQc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -14697,18 +14673,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"hQp" = (
-/obj/machinery/light/directional/west,
-/obj/structure/sign/warning/secure_area/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
-"hQI" = (
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "MiniSat Chamber Port";
-	network = list("minisat")
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "hRq" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/turf_decal/tile/holiday/random,
@@ -14733,13 +14697,9 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "hRR" = (
-/obj/docking_port/stationary/random{
-	name = "lavaland";
-	shuttle_id = "pod_4_lavaland";
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "hSn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -14933,12 +14893,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "hXb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/random/bureaucracy/pen,
+/turf/open/floor/iron,
+/area/station/science/explab)
 "hXj" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -14998,6 +14961,11 @@
 "hYb" = (
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"hYj" = (
+/obj/machinery/requests_console/directional/west,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "hYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -15021,16 +14989,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hZr" = (
-/obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = 7
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/item/multitool/circuit,
-/obj/item/multitool/circuit{
-	pixel_x = -8
-	},
-/turf/open/floor/circuit,
-/area/station/science/circuits)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "hZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -15109,6 +15072,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"iaI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "iaT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -15401,17 +15374,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "ilN" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 16
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "ilO" = (
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/dark,
@@ -15520,18 +15486,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ipw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "ipJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -15585,11 +15542,8 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "iqM" = (
-/obj/effect/landmark/start/cyborg,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "iqX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -15620,14 +15574,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "ism" = (
-/obj/machinery/requests_console{
-	department = "Science";
-	name = "Science Requests Console";
-	pixel_x = 30
-	},
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/supplies,
 /obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 16
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "isz" = (
@@ -15802,9 +15757,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "iyc" = (
-/obj/machinery/computer/station_alert,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/camera/motion/directional/north{
+	network = list("minisat");
+	c_tag = "MiniSat External Aft"
+	},
+/turf/open/space/basic,
+/area/space)
 "iym" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -15846,12 +15804,6 @@
 "izI" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
-"iAn" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "iAw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -16174,7 +16126,7 @@
 "iIT" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
+/area/station/science/ordnance)
 "iIV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16201,25 +16153,17 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "iJE" = (
-/obj/effect/landmark/start/ai,
-/obj/item/radio/intercom/directional/south{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom"
-	},
-/obj/item/radio/intercom/directional/north{
-	frequency = 1447;
-	name = "Private Channel";
-	freerange = 1
-	},
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel"
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/closet,
+/obj/item/circuitboard/machine/exoscanner,
+/obj/item/circuitboard/machine/exoscanner,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/fuel_pellet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "iJH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -16249,6 +16193,14 @@
 /obj/effect/gibspawner/confetti,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"iJY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "iKj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -16340,12 +16292,6 @@
 /obj/effect/spawner/random/maintenance/seven,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"iNH" = (
-/obj/machinery/ai_slipper{
-	uses = 8
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "iNN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -17107,15 +17053,9 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "jhZ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "jie" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -17326,24 +17266,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
-"jph" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "jpj" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/machinery/light/directional/west,
+/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jpo" = (
@@ -17747,13 +17672,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"jAi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "jAC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17876,12 +17794,12 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "jCW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "jDA" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -18055,7 +17973,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jIb" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/glasses/monocle,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "jIo" = (
@@ -18141,14 +18059,9 @@
 /area/station/service/kitchen)
 "jLI" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 11
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/station/science/circuits)
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "jLL" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -18170,10 +18083,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"jME" = (
-/obj/structure/transit_tube,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "jMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18442,9 +18351,11 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
 "jTu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/cytology)
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "jTz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -18689,10 +18600,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
-"kan" = (
-/obj/effect/landmark/start/ai/secondary,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "kaO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -19063,9 +18970,9 @@
 /turf/open/floor/carpet/cyan,
 /area/station/medical/psychology)
 "kmf" = (
-/obj/effect/turf_decal/siding/purple,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "kmj" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
@@ -19130,6 +19037,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"koa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "kod" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Containment Pen #1";
@@ -19148,22 +19061,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "koC" = (
-/obj/machinery/netpod,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "koL" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -19239,17 +19142,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "krl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "krn" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -19600,11 +19498,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"kAA" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "kAD" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -19761,8 +19654,10 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "kFI" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "kFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -19951,9 +19846,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"kMZ" = (
-/turf/open/floor/iron/dark,
-/area/station/science/circuits)
 "kNk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/chair{
@@ -19962,10 +19854,19 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/hallway/primary/starboard)
 "kNB" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "kNX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -19996,11 +19897,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "kOE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
+/obj/machinery/camera/directional/south{
+	c_tag = "Xeno Pens South C";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "kOS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -20026,12 +19928,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/starboard)
 "kPD" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Xeno Pens South C";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/computer/exoscanner_control,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "kPG" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20224,12 +20123,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kVJ" = (
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","qm")
+/obj/docking_port/stationary/random{
+	name = "lavaland";
+	shuttle_id = "pod_4_lavaland";
+	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/turf/open/space/basic,
+/area/space)
 "kVL" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -20552,10 +20452,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ldE" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/item/storage/bag/money,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "lee" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/cafeteria,
@@ -20778,6 +20677,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"ljJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "ljK" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -21029,12 +20932,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lsD" = (
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "MiniSat External Starboard";
-	network = list("minisat")
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "lsG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -21138,10 +21045,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"lvh" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "lvv" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -21224,11 +21127,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "lwZ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "lxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -21619,6 +21521,12 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"lKA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "lKG" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -21669,11 +21577,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lLE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/smartfridge/petri/preloaded,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "lLL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21698,13 +21606,11 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "lMk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "lMn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21790,12 +21696,23 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "lOu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
+/obj/machinery/turretid{
+	control_area = "/area/station/ai_monitored/turret_protected/ai";
+	name = "AI Chamber turret control";
+	pixel_x = 5;
+	pixel_y = -24
 	},
+/obj/machinery/newscaster/directional/west,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat AI Chamber Core";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "lOH" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/r_wall,
@@ -21900,6 +21817,15 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"lTa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "lTv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -22232,25 +22158,22 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"mba" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
 "mbw" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/service/library)
 "mbG" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "MiniSat External Port";
-	network = list("minisat")
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "mbQ" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -22490,11 +22413,14 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "mgO" = (
-/obj/item/shrapnel/bullet,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
+/obj/machinery/light/floor{
+	brightness = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "mgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -22522,12 +22448,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mhC" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "mhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -22548,9 +22473,11 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "mii" = (
-/obj/structure/closet/bombcloset,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/machinery/netpod,
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "mim" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -22643,6 +22570,10 @@
 "mjS" = (
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
+"mkZ" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "mlf" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -22790,11 +22721,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "moX" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai_monitored/turret_protected/ai)
 "mpk" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine{
@@ -22945,9 +22873,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "mrQ" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "mrW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -23432,24 +23363,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/break_room)
 "mEE" = (
-/obj/machinery/door/airlock/research{
-	name = "Testing Chamber"
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "experimentation-lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "mFd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23497,7 +23415,7 @@
 	name = "server vent"
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "mHE" = (
@@ -23754,10 +23672,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "mNQ" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "mNS" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -23919,6 +23836,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mSA" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "mSB" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -23973,9 +23905,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "mUc" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "mUo" = (
 /obj/structure/sign/warning/secure_area{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -24087,10 +24028,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mVM" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "mVN" = (
 /obj/structure/table,
 /obj/machinery/door/window/left/directional/west{
@@ -24296,6 +24237,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"nbr" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/xenobio_guide/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "nbw" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -24378,6 +24324,10 @@
 "ndp" = (
 /turf/open/floor/wood,
 /area/station/service/library)
+"ndD" = (
+/obj/machinery/chem_master,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "ndH" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -24481,11 +24431,15 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "ngh" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/cargo/drone_bay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "ngi" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -24552,20 +24506,6 @@
 /obj/item/seeds/garlic,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"nhk" = (
-/obj/structure/cable,
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "nhv" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -24615,9 +24555,13 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "niS" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/xenobiology)
+/area/station/service/janitor)
 "niY" = (
 /obj/machinery/button/door{
 	id = "Pillshutters";
@@ -24661,10 +24605,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "njG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "njQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -24694,14 +24638,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nkK" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/structure/table,
+/obj/item/multitool/circuit{
+	pixel_x = 7
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit{
+	pixel_x = -8
+	},
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "nkW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24852,11 +24798,9 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hop)
 "noh" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage_shared)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "nol" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment{
@@ -24917,15 +24861,9 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "nps" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/window/right/directional/south{
-	name = "Xenobiology Desk";
-	req_access = list("xenobiology")
-	},
-/obj/structure/desk_bell,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "npu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -24997,9 +24935,8 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "nqU" = (
-/obj/structure/transit_tube,
-/turf/closed/wall,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/plating/airless,
+/area/space)
 "nru" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -25201,10 +25138,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "nwh" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "MiniSat Chamber Port";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "nwq" = (
 /obj/structure/rack,
 /turf/open/floor/iron/dark,
@@ -25380,16 +25319,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "nCH" = (
-/obj/structure/bed/dogbed{
-	name = "Bobbernaut's Beb"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/mob/living/basic/slime/pet{
-	slime_type = /datum/slime_type/purple;
-	desc = "The Science Divisions pet slime. Isn't it adorable when it bobbles around?";
-	name = "Bobbernaut"
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "nCI" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
@@ -25412,13 +25346,12 @@
 /turf/open/floor/iron,
 /area/station/security)
 "nDx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "nDF" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -25464,12 +25397,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "nEw" = (
-/obj/effect/spawner/random/trash/garbage,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "nEN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26048,11 +25979,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "nUx" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/turf/open/floor/circuit,
-/area/station/science/circuits)
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "nUM" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
@@ -26133,13 +26065,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "nXv" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/computer/atmos_control/ordnancemix{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/purple,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/research)
 "nXC" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -26166,9 +26097,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nYi" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
+/obj/structure/table,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "nYk" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
@@ -26441,8 +26373,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oeI" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/circuit,
 /area/station/science/circuits)
 "oeP" = (
@@ -26505,21 +26438,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ogI" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ogP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"ogV" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "ogY" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
@@ -26621,12 +26550,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ojr" = (
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "MiniSat External Fore";
-	network = list("minisat")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "oju" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26824,6 +26752,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"oou" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "ooG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -27094,11 +27034,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ovt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","qm")
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "ovE" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/north,
@@ -27145,21 +27086,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "owN" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
-"owS" = (
+/obj/machinery/door/airlock/mining/glass{
+	id_tag = "innercargo";
+	name = "Bitrunning Club"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /obj/structure/cable,
-/obj/machinery/button/door{
-	id = "misclab";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/old{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/area/station/cargo/bitrunning/den)
 "oxk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -27291,6 +27229,13 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"oAx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "oAI" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
@@ -27528,14 +27473,12 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "oIu" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "MiniSat Chamber Foyer";
-	network = list("minisat")
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/structure/sign/warning/secure_area/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "oII" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -27767,13 +27710,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "oQz" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "stationawaygate";
-	name = "Gateway Access Shutters"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/command/gateway)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "oQO" = (
 /obj/item/book/random,
 /obj/effect/decal/cleanable/cobweb,
@@ -27841,12 +27786,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"oSQ" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/command/heads_quarters/rd)
 "oTg" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
@@ -27973,11 +27912,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "oVU" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining"
-	},
+/obj/structure/closet/toolcloset,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/area/station/commons/storage/tools)
 "oWb" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/latex,
@@ -28020,13 +27959,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
 "oXw" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science{
-	pixel_y = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/explab)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "oXI" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -28339,6 +28276,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"pfs" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "pfS" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -28536,19 +28480,22 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "pjV" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/trash/garbage,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "pkv" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/smartfridge/petri/preloaded,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "pkA" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/west,
@@ -28687,12 +28634,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "poS" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/turf/open/floor/iron/dark,
+/obj/machinery/holopad/secure,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "poT" = (
 /obj/structure/table,
@@ -28820,12 +28763,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"prm" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
 "prp" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -29049,6 +28986,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"pxa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "pxp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -29094,8 +29039,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pyy" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "pyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -29127,13 +29075,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"pzm" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/courtroom)
 "pzq" = (
 /obj/structure/table,
 /obj/item/seeds/wheat/rice,
@@ -29294,6 +29235,17 @@
 "pEb" = (
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"pEl" = (
+/obj/machinery/requests_console{
+	department = "Science";
+	name = "Science Requests Console";
+	pixel_x = 30
+	},
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/table/glass,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "pED" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -29379,10 +29331,15 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "pGY" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/extinguisher,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pHb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29452,11 +29409,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pIs" = (
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat Chamber Starboard";
+	network = list("minisat")
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pIF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29822,11 +29780,11 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "pRG" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+/obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/space/nearstation)
+/turf/open/floor/iron/cafeteria,
+/area/station/command/heads_quarters/rd)
 "pSn" = (
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/iron,
@@ -29845,13 +29803,6 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"pSA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
 "pSB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -29981,13 +29932,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pVw" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
 	},
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "pVE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -30236,12 +30192,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qbD" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/machinery/button/door{
+	id = "misclab";
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "qbG" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/iron,
@@ -30344,6 +30304,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"qeq" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "qeR" = (
 /obj/machinery/status_display/door_timer{
 	id = "Cell 3";
@@ -30378,11 +30343,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "qfN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/item/gun/ballistic/revolver/russian,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "qga" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron/showroomfloor,
@@ -30552,6 +30517,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
+"qkV" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "qkW" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot_red,
@@ -30729,6 +30698,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"qpq" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "qpt" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 1
@@ -30856,6 +30839,10 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"qsw" = (
+/obj/machinery/vending/cola/starkist,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "qsN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Gas to Chamber"
@@ -30875,11 +30862,10 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
 "qtC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/station/science/circuits)
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "qtF" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
@@ -30904,6 +30890,20 @@
 "qtX" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"qud" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "qup" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -30969,12 +30969,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qvJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "qwk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31038,10 +31037,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "qwG" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "qwH" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -31106,14 +31104,21 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "qxZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/crushed_can,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
+"qyo" = (
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "qyp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -31227,10 +31232,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qAP" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "qAQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -31753,23 +31759,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"qLX" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
-"qMb" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Drone Hangar"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/drone_bay)
 "qMi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -31795,11 +31784,17 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "qMw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qME" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -31970,6 +31965,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"qQT" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "qQV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mining{
@@ -32009,11 +32010,17 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "qRp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/leafy,
+/turf/open/floor/grass,
+/area/station/medical/virology)
+"qRq" = (
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat Chamber Aft";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "qRu" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
@@ -32202,8 +32209,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "qUy" = (
-/obj/machinery/computer/exodrone_control_console,
-/obj/item/radio/intercom/directional/north,
+/obj/item/shrapnel/bullet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "qUC" = (
@@ -32352,11 +32360,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "qXt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/structure/closet/bombcloset,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/science/ordnance)
 "qXG" = (
 /obj/structure/light_construct{
 	dir = 4
@@ -32369,13 +32375,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "qXX" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Cytology Chamber";
-	req_access = list("science")
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "qYf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -32479,13 +32484,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "qZR" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "rac" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -32528,11 +32530,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rbD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/machinery/computer/monitor,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "rbP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -32598,12 +32598,15 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "rdk" = (
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "MiniSat Chamber Aft";
-	network = list("minisat")
+/obj/item/radio/intercom/directional/east{
+	broadcasting = 1;
+	listening = 0;
+	frequency = 1447
 	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "rdA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -32689,9 +32692,15 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/rd)
 "rfN" = (
-/obj/item/storage/bag/money,
-/turf/open/floor/plating/rust,
-/area/station/maintenance/port/aft)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "rfP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32782,12 +32791,10 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/fitness)
 "rio" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/closet/l3closet/scientist,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "riw" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -32990,15 +32997,15 @@
 /area/station/cargo/office)
 "rox" = (
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
+/obj/item/biopsy_tool{
 	pixel_x = -5;
-	pixel_y = 14
+	pixel_y = 2
 	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 10;
-	pixel_y = 3
+/obj/item/book/manual/wiki/cytology{
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/cytology)
 "roA" = (
@@ -33096,10 +33103,9 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/captain)
 "rqO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/structure/transit_tube,
+/turf/closed/wall,
+/area/station/maintenance/fore/lesser)
 "rrm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33162,18 +33168,20 @@
 /turf/open/space,
 /area/space/nearstation)
 "rsh" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "rsw" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/station/ai_monitored/turret_protected/ai)
 "rsF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -33392,9 +33400,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rwK" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/library)
 "rwL" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33555,16 +33566,23 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "rAh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rAn" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Xenobiology"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "rAz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
@@ -33802,12 +33820,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "rFs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/effect/landmark/start/ai/secondary,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "rFu" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -34153,12 +34168,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"rOE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar)
 "rPt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/computer/operating{
@@ -34329,17 +34338,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "rUj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "rUn" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/computer/camera_advanced/base_construction/aux{
@@ -34393,6 +34395,9 @@
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
+	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
@@ -34804,14 +34809,8 @@
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
 "sgY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/science/circuits)
 "shk" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -34867,6 +34866,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/misc/dirt,
 /area/station/security/prison)
+"sjw" = (
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "sjD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34889,12 +34892,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "sjX" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/machinery/door/airlock/atmos{
+	name = "Gas Storage"
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "sjZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -35064,14 +35069,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "spO" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/camera/autoname/directional/west{
-	network = list("ss13","qm")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/cargo/drone_bay)
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "spS" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -35092,10 +35098,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"sqg" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/science/robotics/mechbay)
 "sqp" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -35228,11 +35230,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ssO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "stc" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -35256,13 +35258,13 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "stV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/window/left/directional/south{
+	name = "Cytology Chamber";
+	req_access = list("science")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "sux" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35499,6 +35501,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"sDk" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "sDJ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -35595,6 +35604,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"sFG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "sGl" = (
 /obj/effect/gibspawner/human,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -35620,11 +35644,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "sHt" = (
-/obj/item/gun/ballistic/revolver/russian,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit)
 "sHw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36080,7 +36104,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "sVh" = (
-/obj/structure/cable,
+/obj/structure/sign/poster/official/safety_report/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/cytology)
 "sVm" = (
@@ -36179,15 +36203,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "sYT" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "sYU" = (
 /obj/item/paint/anycolor{
 	pixel_x = 8
@@ -36226,11 +36248,13 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central)
 "tak" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 5
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "taI" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -36282,15 +36306,12 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/hos)
 "tbD" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tbM" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -36540,6 +36561,16 @@
 /obj/item/circuitboard/computer/advanced_camera,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"tht" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "thG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -36647,6 +36678,10 @@
 /obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"tko" = (
+/obj/structure/transit_tube,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "tkq" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -37007,16 +37042,11 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "tuO" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access"
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","rd")
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "tuP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37286,12 +37316,6 @@
 "tCf" = (
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"tCg" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/kitchen)
 "tCq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37771,12 +37795,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "tPd" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Containment Pen #2";
-	req_access = list("xenobiology")
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "tPe" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
@@ -38181,10 +38205,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "uau" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/sign/xenobio_guide/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "uaw" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -38221,17 +38248,9 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "ubm" = (
-/obj/machinery/requests_console/directional/south{
-	department = "AI";
-	name = "AI Chamber Requests Console";
-	pixel_y = 30
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/computer/station_alert,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "ubu" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/sepia,
@@ -38291,10 +38310,6 @@
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"ucw" = (
-/obj/machinery/chem_master,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "ucA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -38439,6 +38454,10 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"ugB" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/lesser)
 "ugO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38453,6 +38472,25 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/royalblack,
 /area/station/commons/dorms)
+"uhv" = (
+/obj/machinery/door/airlock/research{
+	name = "Testing Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "experimentation-lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "uhE" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -38467,14 +38505,10 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "uil" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "uiw" = (
 /obj/machinery/computer/crew{
@@ -38673,11 +38707,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "unw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/primary/starboard)
 "unE" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/shower/directional/north,
@@ -38932,11 +38967,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"uso" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
 "usH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39079,12 +39109,9 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance)
 "uvX" = (
-/obj/structure/transit_tube/station/dispenser/reverse/flipped{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/module_duplicator,
+/turf/open/floor/circuit,
+/area/station/science/circuits)
 "uwk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -39122,8 +39149,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "uxo" = (
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "uxq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39211,10 +39242,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"uBl" = (
-/obj/item/clothing/glasses/monocle,
-/turf/open/floor/plating/rust,
-/area/station/maintenance/port/aft)
 "uBo" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -39576,12 +39603,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "uKU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen #2";
+	req_access = list("xenobiology")
 	},
-/obj/structure/sign/warning/no_smoking/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uKW" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -39695,9 +39722,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "uMV" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "uNt" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 4
@@ -39910,12 +39943,6 @@
 "uST" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
-"uTq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
 "uTH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -40122,13 +40149,8 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "uYC" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "uYG" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
@@ -40192,8 +40214,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uZw" = (
-/obj/structure/cable,
-/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/status_display/ai/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
@@ -40202,6 +40223,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"uZF" = (
+/obj/machinery/computer/mechpad{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "uZP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -40305,17 +40332,12 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "vbV" = (
-/obj/machinery/light/floor{
-	brightness = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/engineering/supermatter/room)
 "vbX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -40461,11 +40483,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vgu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "vgx" = (
 /obj/structure/table,
 /obj/item/stock_parts/capacitor{
@@ -40531,12 +40558,11 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "viz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air Out"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "viI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40750,17 +40776,11 @@
 /turf/open/floor/grass,
 /area/station/security/prison)
 "voq" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_y = 20
+/obj/machinery/camera/motion/directional/north{
+	network = list("minisat");
+	c_tag = "MiniSat Chamber Fore"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "vov" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40769,6 +40789,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "voy" = (
@@ -41000,13 +41021,13 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "vuk" = (
-/obj/machinery/light/floor{
-	brightness = 10
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics2";
+	name = "Robotics Lab Shutters"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "vuu" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -41085,11 +41106,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"vvB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen)
 "vvH" = (
 /obj/structure/table,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/circuit,
 /area/station/science/circuits)
 "vvJ" = (
@@ -41161,11 +41193,12 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
 "vxh" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "vxF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -41368,15 +41401,15 @@
 /area/station/service/janitor)
 "vCK" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/structure/microscope,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -4;
+	pixel_y = -11
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/cytology)
 "vCP" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -41661,9 +41694,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vIf" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/requests_console/directional/south{
+	department = "AI";
+	name = "AI Chamber Requests Console";
+	pixel_y = 30
+	},
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "vIl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41678,13 +41719,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"vID" = (
-/obj/machinery/camera/motion/directional/north{
-	network = list("minisat");
-	c_tag = "MiniSat Chamber Fore"
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "vIJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -41714,9 +41748,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vJv" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/digital_clock/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "vJJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -41754,12 +41788,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vKA" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "vKV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/newscaster/directional/south,
@@ -41848,12 +41882,15 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "vNm" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "vNu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42104,6 +42141,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"vUn" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/computer/atmos_control/ordnancemix{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "vUw" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/pods/directional/east,
@@ -42137,10 +42182,15 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "vWk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vWn" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
@@ -42520,11 +42570,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"wfQ" = (
-/obj/machinery/requests_console/directional/west,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "wfW" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -42636,18 +42681,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "win" = (
-/obj/machinery/door/airlock/mining/glass{
-	id_tag = "innercargo";
-	name = "Bitrunning Club"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs/old{
-	dir = 8
-	},
-/area/station/cargo/bitrunning/den)
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "wiq" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -42730,13 +42766,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wjQ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/service/janitor)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "wkg" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -42889,14 +42925,22 @@
 	},
 /area/station/hallway/primary/central)
 "wnp" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "wnK" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"wnP" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "wnS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -42909,6 +42953,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
+"wnY" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "woa" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -42991,6 +43039,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"wpd" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "wpB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -43031,11 +43084,14 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "wqD" = (
-/obj/effect/turf_decal/siding/purple/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wqM" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -43141,10 +43197,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "wsA" = (
-/obj/machinery/quantum_server,
-/obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "wsQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -43193,13 +43248,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"wuw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "wuX" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -43261,11 +43309,9 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "wwt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/xenobiology)
+/area/station/science/robotics/lab)
 "wwL" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -43614,12 +43660,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "wDk" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/drone_bay)
 "wDo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -43815,15 +43860,12 @@
 /turf/open/floor/plating,
 /area/station/security/brig)
 "wHB" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/random/bureaucracy/pen,
-/turf/open/floor/iron,
-/area/station/science/explab)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "wHR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44318,10 +44360,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wVw" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/leafy,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/door/airlock/mining{
+	name = "Drone Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/old{
+	dir = 8
+	},
+/area/station/cargo/drone_bay)
 "wVA" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine,
@@ -44388,14 +44437,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wXw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/window/right/directional/east{
+	name = "Drone Hangar"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/research)
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "wXy" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -44601,13 +44647,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "xdx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "xdE" = (
@@ -44627,14 +44675,12 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "xdX" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Gas Storage"
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "MiniSat External Fore";
+	network = list("minisat")
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/turf/open/space/basic,
+/area/space)
 "xef" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/showroomfloor,
@@ -44781,16 +44827,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xhc" = (
-/obj/structure/table/glass,
-/obj/structure/microscope,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -4;
-	pixel_y = -11
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/station/science/cytology)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "xhf" = (
 /obj/machinery/requests_console{
 	department = "Head of Personnel's Desk";
@@ -44833,13 +44876,13 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "xix" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics2";
-	name = "Robotics Lab Shutters"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/science/robotics/lab)
+/area/station/maintenance/starboard/fore)
 "xiU" = (
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
@@ -44886,13 +44929,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "xlh" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "aux_base_shutters";
-	name = "Auxillary Base Shutters"
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "xlR" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -45210,12 +45251,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "xrY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "xsf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -45281,6 +45321,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"xud" = (
+/obj/effect/landmark/start/cyborg,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "xui" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45557,11 +45603,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"xBA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
 "xBL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -45968,12 +46009,11 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "xKv" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/station/science/ordnance)
 "xKE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -45996,6 +46036,12 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"xKI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/theater)
 "xLA" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/book/bible/booze,
@@ -46445,16 +46491,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"xYA" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
 "xYK" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
+/obj/structure/table,
+/obj/item/mmi,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/ecto_sniffer{
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -46673,11 +46716,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
-"ydq" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/courtroom)
 "ydr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -46826,17 +46864,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ygS" = (
-/obj/structure/closet,
-/obj/item/circuitboard/machine/exoscanner,
-/obj/item/circuitboard/machine/exoscanner,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/item/fuel_pellet,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/cargo/drone_bay)
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "ygV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58718,7 +58750,7 @@ vlu
 mDS
 eOL
 elT
-kmf
+nps
 dAC
 jOX
 cag
@@ -58932,7 +58964,7 @@ lZu
 fxJ
 teQ
 xxr
-gRc
+kFI
 vTy
 aOa
 mUs
@@ -58945,7 +58977,7 @@ pbL
 mDS
 eOL
 bjM
-kmf
+nps
 dAC
 jOX
 mnr
@@ -59172,7 +59204,7 @@ pbL
 nET
 eOL
 biK
-kmf
+nps
 dAC
 jOX
 jyX
@@ -59399,7 +59431,7 @@ vLX
 gcC
 eOL
 rIO
-rFs
+nUx
 dAC
 fvW
 ext
@@ -59601,7 +59633,7 @@ rFl
 uje
 xPc
 eXk
-hzV
+fxq
 uje
 qdM
 piv
@@ -59625,8 +59657,8 @@ cqf
 dwF
 akJ
 eOL
-uKU
-kmf
+gSo
+nps
 dAC
 xes
 bOY
@@ -59853,7 +59885,7 @@ pbL
 sLg
 eOL
 xIg
-rFs
+nUx
 dAC
 pXB
 dAC
@@ -60080,7 +60112,7 @@ fmc
 gcC
 eOL
 vkK
-kmf
+nps
 dAC
 bOY
 dAC
@@ -60289,9 +60321,9 @@ rxJ
 dja
 gLK
 ksv
-jAi
-jAi
-jAi
+dIr
+dIr
+dIr
 goP
 qFP
 tVN
@@ -60307,19 +60339,19 @@ lsO
 gcC
 eOL
 cfs
-rFs
+nUx
 dAC
 bOY
 dAC
 iIT
-jhj
-jhj
-jhj
-jhj
-jhj
-jhj
-jhj
-jhj
+pwP
+pwP
+pwP
+pwP
+pwP
+pwP
+pwP
+pwP
 xii
 xii
 xii
@@ -60533,12 +60565,12 @@ cqf
 pbL
 ulc
 eOL
-mii
-pIs
+qXt
+xKv
 dqk
 bOY
 dAC
-jhj
+pwP
 rGn
 jjs
 uQK
@@ -60732,8 +60764,8 @@ toX
 pau
 nhi
 bSf
-lOu
-vNm
+eTN
+rwK
 qzS
 qZs
 oEZ
@@ -60760,12 +60792,12 @@ cqf
 pbL
 gcC
 eOL
-mii
+qXt
 lOd
-kmf
+nps
 bOY
 bSn
-jhj
+pwP
 kNZ
 cgh
 uQK
@@ -60990,9 +61022,9 @@ eOL
 ksk
 wkg
 csL
-div
+vKA
 sXz
-jhj
+pwP
 gRC
 jjs
 uQK
@@ -61216,10 +61248,10 @@ iXv
 eOL
 vGb
 fwe
-kmf
+nps
 azD
 xmV
-jhj
+pwP
 vig
 oCQ
 uQK
@@ -61228,7 +61260,7 @@ kod
 uQK
 uQK
 uQK
-tPd
+uKU
 uQK
 uQK
 uQK
@@ -61443,10 +61475,10 @@ kVL
 eOL
 spK
 vQy
-nXv
+vUn
 mXt
 sUN
-jhj
+pwP
 wuf
 cIe
 nMO
@@ -61460,7 +61492,7 @@ nMO
 pYB
 xtn
 cIe
-pSA
+awv
 xii
 vtB
 fSl
@@ -61673,21 +61705,21 @@ pwP
 pwP
 egx
 pwP
-jhj
+pwP
 myi
-vxh
-vxh
-vxh
-vxh
-vxh
-vxh
-vxh
-wqD
-rbD
+jTu
+jTu
+jTu
+jTu
+jTu
+jTu
+jTu
+mEE
+dyc
 aDD
 aDD
 aDD
-mba
+avs
 xii
 vtB
 eWS
@@ -61897,20 +61929,20 @@ eOL
 xVe
 cIM
 jlx
-rio
+ggq
 hmd
 pOC
-jhj
+xfK
 mFN
 xgI
-ucw
+ndD
 veO
 gFF
 veO
 diL
-fUa
+mrQ
 qwD
-ovt
+pyy
 uQK
 uQK
 uQK
@@ -62124,20 +62156,20 @@ eOL
 mGw
 rWr
 jlx
-wnp
+hRR
 rHl
 nYV
-uQK
+edL
 veO
 veO
-ggk
-vgu
-arJ
+njG
+fss
+hzV
 veO
-cdF
-rsh
+dyg
+koL
 qwD
-dIr
+bXc
 uQK
 tJM
 tJM
@@ -62353,19 +62385,19 @@ gwU
 mUo
 ujF
 aFF
-rUj
-koL
+xdx
+rAn
 ryS
-vbV
+bYT
+lTa
 vov
-vov
-uil
-vbV
-vov
-vCK
-krl
-ipw
-bdD
+oQz
+bYT
+lTa
+vWk
+qMw
+mUc
+hhU
 tJM
 oZL
 pYU
@@ -62578,20 +62610,20 @@ eOL
 vsO
 xvZ
 tCb
-hXb
+nXv
 egX
-wXw
-nps
+dNM
+ftm
 veO
 qKp
-pjV
+tak
 veO
 veO
 veO
 veO
 veO
 qwD
-agK
+sFG
 uQK
 tJM
 tJM
@@ -62606,9 +62638,9 @@ pRn
 xii
 xii
 xii
-jhj
-jhj
-jhj
+xii
+xii
+xii
 bXj
 bXj
 bXj
@@ -62805,20 +62837,20 @@ eOL
 qYu
 vOC
 jlx
-qvJ
+feG
 cGy
 ruQ
-uQK
+edL
 jyp
 sRQ
+pEl
 ism
-ilN
 hvG
-uau
+nbr
 veO
 veO
 qwD
-aGU
+qxZ
 uQK
 uQK
 uQK
@@ -62835,8 +62867,8 @@ jUl
 tJM
 tJM
 tJM
-jhj
-gBM
+xii
+pRn
 ggx
 ggx
 ggx
@@ -63048,11 +63080,11 @@ vGT
 qaB
 qKK
 aDD
-uso
+lwZ
 xbU
 hvQ
 wDi
-njG
+dGo
 gBM
 aZG
 uWX
@@ -63062,9 +63094,9 @@ icY
 aYy
 rGd
 tJM
-jhj
-gBM
-gBM
+xii
+pRn
+pRn
 bXj
 bXj
 bXj
@@ -63263,25 +63295,25 @@ vFY
 qup
 nYV
 fMY
-xhc
-dDo
+vCK
 rox
-kHv
+fzf
+tuO
 kHv
 vBw
-pGY
+lMk
 nts
 xTy
-wwt
+uil
 jkE
 nts
-uYC
+wjQ
 jhj
 hvq
-gdH
-niS
+pGY
+kmf
 gBM
-owS
+qbD
 iBa
 iTy
 ffn
@@ -63289,9 +63321,9 @@ jUl
 tJM
 tJM
 tJM
-jhj
-hlK
-uQK
+xii
+sEb
+jjS
 bXj
 bXj
 bXj
@@ -63490,11 +63522,11 @@ vFY
 qup
 nYV
 krn
-sVh
-uTq
+sjw
+oXw
 scL
 kHv
-bYT
+sVh
 vBw
 uQK
 eXq
@@ -63505,7 +63537,7 @@ eQf
 uQK
 jhj
 rCW
-gdH
+pGY
 hJL
 omD
 pFL
@@ -63515,10 +63547,10 @@ gyo
 jUl
 aUD
 udw
-uMV
-jhj
+qwG
+xii
 dVr
-uQK
+jjS
 bXj
 bXj
 bXj
@@ -63714,14 +63746,14 @@ lwJ
 ivt
 rfk
 vFY
-bSj
+kNB
 uLJ
 gTB
-qMw
-vuk
-qXX
+koa
+mgO
+stV
 kHv
-dqd
+fvt
 vBw
 tJM
 tJM
@@ -63732,10 +63764,10 @@ tJM
 tJM
 jhj
 kXk
-gdH
-niS
+pGY
+kmf
 gBM
-hdi
+aLO
 fGr
 iTy
 ffn
@@ -63743,9 +63775,9 @@ jUl
 tJM
 tJM
 tJM
-jhj
-hlK
-uQK
+xii
+sEb
+jjS
 bXj
 bXj
 bXj
@@ -63934,7 +63966,7 @@ cqf
 cqf
 mDS
 eOL
-nCH
+diW
 ivt
 cOH
 gLf
@@ -63945,24 +63977,24 @@ bEC
 nYV
 krn
 kHv
-tak
+nCH
 scL
 kHv
 kHv
-jTu
+noh
 tJM
 xHL
 tJM
 uQK
 tJM
 xHL
-kPD
+kOE
 jhj
 hJj
 mLQ
-vWk
+hZr
 gBM
-cdl
+nYi
 iBa
 pYB
 ffn
@@ -63970,8 +64002,8 @@ jUl
 tJM
 tJM
 tJM
-jhj
-ogY
+xii
+xii
 ogY
 ogY
 tNf
@@ -64153,7 +64185,7 @@ dpp
 vlu
 khs
 cqf
-hHD
+ciC
 qFY
 dwF
 vvO
@@ -64162,9 +64194,9 @@ vvO
 mDS
 eOL
 oHs
-oSQ
+pRG
 csj
-oSQ
+pRG
 cLT
 dMa
 gbU
@@ -64173,7 +64205,7 @@ nYV
 fMY
 apx
 xef
-pkv
+lLE
 kHv
 kHv
 vBw
@@ -64197,8 +64229,8 @@ fjc
 tJM
 tJM
 tJM
-jhj
-ogY
+xii
+xii
 qFz
 aIQ
 nwy
@@ -64626,7 +64658,7 @@ hdT
 vIl
 xhQ
 gmc
-bEe
+uvX
 xnr
 afL
 qLu
@@ -64852,8 +64884,8 @@ nYV
 hdT
 nYV
 xhQ
+hPH
 oeI
-qtC
 ftR
 afL
 mWB
@@ -65082,7 +65114,7 @@ ocE
 fWT
 jdP
 wcd
-mEE
+uhv
 sQa
 env
 nbz
@@ -65306,7 +65338,7 @@ hKG
 hdT
 nYV
 uBq
-kMZ
+sgY
 wRv
 jtR
 afL
@@ -65496,7 +65528,7 @@ qvA
 qvA
 ory
 xgU
-rqO
+rio
 oef
 oef
 qxi
@@ -65516,7 +65548,7 @@ vlu
 aze
 cqf
 wBj
-wjQ
+niS
 mXR
 fCd
 cqf
@@ -65534,7 +65566,7 @@ hdT
 nYV
 xhQ
 mmO
-nUx
+gqV
 ftR
 afL
 juD
@@ -65758,16 +65790,16 @@ iup
 apa
 glW
 rIH
-xdx
+eBw
 xhQ
+fXg
+nkK
 vvH
-hZr
-jLI
 afL
-oXw
+bSj
 eGP
-wHB
-bBM
+hXb
+jhZ
 sML
 bDo
 bDo
@@ -65970,7 +66002,7 @@ fFM
 ebX
 cqf
 coN
-wjQ
+niS
 sEo
 bPF
 cqf
@@ -65987,9 +66019,9 @@ tug
 qKN
 nYV
 qTO
-xix
-xix
-xix
+vuk
+vuk
+vuk
 afL
 afL
 afL
@@ -66217,12 +66249,12 @@ qTO
 oDM
 crg
 crg
-hrl
 agj
+wwt
 elI
 tYk
-xKv
-cvW
+dqd
+xYK
 wmI
 vpf
 iOn
@@ -66447,16 +66479,16 @@ oOK
 rcX
 uiy
 crg
-xYK
+ygS
 xbm
-qAP
+ciD
 wmI
 dZe
 dZe
 tiA
 xii
 fSl
-cbM
+qud
 pRn
 pRn
 pRn
@@ -66675,8 +66707,8 @@ aLk
 een
 dTM
 roA
-gea
-qRp
+ljJ
+qvJ
 ydX
 dse
 pxM
@@ -66875,7 +66907,7 @@ aNZ
 qbQ
 vaS
 cqf
-hHD
+ciC
 jFJ
 cqf
 lVG
@@ -66901,9 +66933,9 @@ wui
 wui
 iqI
 crg
-xYK
+ygS
 xbm
-jCW
+qXX
 wmI
 mJJ
 xbm
@@ -66915,7 +66947,7 @@ pRn
 qSh
 scx
 pRn
-jIb
+ipw
 uos
 xeS
 pRn
@@ -67129,8 +67161,8 @@ jdU
 obH
 crg
 oBa
-cZQ
-ciC
+uZF
+wnp
 wmI
 bLv
 eCZ
@@ -67369,9 +67401,9 @@ pRn
 pRn
 pRn
 pRn
-uBl
+jIb
 tlN
-rfN
+ldE
 pRn
 bXj
 pRn
@@ -67557,7 +67589,7 @@ qbQ
 lCP
 pes
 rVb
-prm
+oVU
 xEa
 aTC
 xYe
@@ -67782,7 +67814,7 @@ qDD
 sNj
 sNj
 wYe
-nYi
+koC
 sDK
 qlW
 xEa
@@ -68040,8 +68072,8 @@ owA
 qDM
 fxt
 fxt
-sqg
-iqM
+fRq
+xud
 pRn
 nxC
 qJW
@@ -68721,7 +68753,7 @@ lFd
 hsF
 jEi
 uEm
-bDt
+vgu
 woR
 hlU
 svd
@@ -69401,7 +69433,7 @@ qap
 agG
 oXI
 kEN
-fXW
+aMQ
 rnl
 oTV
 qIb
@@ -70789,7 +70821,7 @@ osd
 mha
 jQx
 vdl
-rsw
+vxh
 gEs
 wfP
 axm
@@ -71243,7 +71275,7 @@ unE
 mha
 jQx
 vdl
-rsw
+vxh
 gEs
 dop
 axm
@@ -71636,8 +71668,8 @@ dNB
 twM
 fOv
 qMo
-oQz
-jph
+cxy
+uxo
 lRW
 jQB
 vBH
@@ -72835,9 +72867,9 @@ tAF
 mRH
 lYQ
 ghL
-hAN
-fgc
-wfQ
+qsw
+nEw
+hYj
 icA
 iDG
 cLw
@@ -73393,13 +73425,13 @@ bXj
 bXj
 bXj
 bXj
-mVM
-mVM
-mVM
-mVM
-mVM
-mVM
-mVM
+cxM
+cxM
+cxM
+cxM
+cxM
+cxM
+cxM
 bXj
 bXj
 bXj
@@ -73623,7 +73655,7 @@ bXj
 bXj
 ggx
 bXj
-mbG
+bsS
 bXj
 ggx
 bXj
@@ -73742,11 +73774,11 @@ oki
 oHS
 uFd
 uFd
-xdX
+sjX
 usc
-ldE
+qeq
 kVG
-ogI
+wsA
 lzE
 uCC
 qqg
@@ -73846,15 +73878,15 @@ bXj
 bXj
 bXj
 bXj
-kFI
-kFI
-kFI
-kFI
-kFI
-kFI
-kFI
-kFI
-kFI
+uYC
+uYC
+uYC
+uYC
+uYC
+uYC
+uYC
+uYC
+uYC
 bXj
 bXj
 bXj
@@ -73965,10 +73997,10 @@ gqW
 xaq
 xCJ
 gko
-noh
-noh
-noh
-noh
+mhC
+mhC
+mhC
+mhC
 ghL
 fIZ
 fIZ
@@ -74072,17 +74104,17 @@ bXj
 bXj
 bXj
 bXj
-kFI
-kFI
-mrQ
-bXc
-bXc
-rwK
-hQI
-bXc
-mrQ
-kFI
-kFI
+uYC
+uYC
+win
+arJ
+arJ
+mNQ
+nwh
+arJ
+win
+uYC
+uYC
 bXj
 bXj
 bXj
@@ -74201,7 +74233,7 @@ tcx
 bnf
 gsz
 fOP
-alQ
+vbV
 uCC
 qqn
 ghL
@@ -74297,21 +74329,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
-kFI
-bXc
-diW
-diW
-diW
-diW
-diW
-diW
-diW
-bXc
-kFI
+uYC
+arJ
+moX
+moX
+moX
+moX
+moX
+moX
+moX
+arJ
+uYC
 bXj
-mVM
+cxM
 bXj
 bXj
 bXj
@@ -74428,7 +74460,7 @@ tcx
 oks
 gsz
 usc
-alQ
+vbV
 ekN
 usc
 ghL
@@ -74524,21 +74556,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 ggx
-kFI
-kan
-diW
-kFI
-kFI
-kFI
-kFI
-kFI
-diW
-kan
-kFI
+uYC
+rFs
+moX
+uYC
+uYC
+uYC
+uYC
+uYC
+moX
+rFs
+uYC
 ggx
-mVM
+cxM
 bXj
 bXj
 bXj
@@ -74655,7 +74687,7 @@ wbT
 oms
 emc
 coY
-alQ
+vbV
 fFn
 gix
 tZW
@@ -74751,21 +74783,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
-kFI
-vID
-ssO
-kFI
-ubm
-pVw
-dFO
-kFI
-fss
-rdk
-kFI
+uYC
+voq
+lKA
+uYC
+vIf
+bVL
+lOu
+uYC
+aHo
+qRq
+uYC
 bXj
-mVM
+cxM
 bXj
 bXj
 bXj
@@ -74978,21 +75010,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
-kFI
-mrQ
-bHX
+uYC
+win
+uMV
+xhc
+hrl
+aGU
 poS
-lvh
-iNH
-gHu
-hsV
-fXg
-mrQ
-kFI
+nDx
+fUa
+win
+uYC
 bXj
-mVM
+cxM
 bXj
 bXj
 bXj
@@ -75205,21 +75237,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
-ojr
-kFI
-eBw
-nhk
-kFI
-kFI
-iJE
-kFI
-kFI
-voq
-vJv
-kFI
-dNM
-mVM
+cxM
+xdX
+uYC
+div
+qpq
+uYC
+uYC
+bxy
+uYC
+uYC
+ccK
+wnY
+uYC
+iyc
+cxM
 bXj
 bXj
 bXj
@@ -75432,21 +75464,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 ggx
-kFI
-bXc
-fzf
-kFI
-kFI
-kFI
-kFI
-kFI
-ciD
-bXc
-kFI
+uYC
+arJ
+ngh
+uYC
+uYC
+uYC
+uYC
+uYC
+rsw
+arJ
+uYC
 ggx
-mVM
+cxM
 bXj
 bXj
 bXj
@@ -75484,7 +75516,7 @@ avr
 fwG
 kzz
 hXj
-nkK
+wqD
 hXj
 vkn
 hXj
@@ -75659,21 +75691,21 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
-kFI
-bXc
-fzf
-fzf
+uYC
+arJ
+ngh
+ngh
+hMy
+mSA
 uZw
-dtM
-edL
-tbD
-ciD
-bXc
-kFI
+pkv
+rsw
+arJ
+uYC
 bXj
-mVM
+cxM
 bXj
 bXj
 bXj
@@ -75886,19 +75918,19 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
-kFI
-kFI
-mrQ
-bXc
-ggq
-fzf
-bXc
-bXc
-mrQ
-kFI
-kFI
+uYC
+uYC
+win
+arJ
+pIs
+iaI
+arJ
+arJ
+win
+uYC
+uYC
 bXj
 bXj
 bXj
@@ -76113,20 +76145,20 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
 bXj
-kFI
-kFI
-kFI
-kFI
-fRq
-kFI
-kFI
-kFI
-kFI
-kFI
-pRG
+uYC
+uYC
+uYC
+uYC
+cyR
+uYC
+uYC
+uYC
+uYC
+uYC
+xlh
 bXj
 bXj
 bXj
@@ -76340,20 +76372,20 @@ bXj
 bXj
 bXj
 bXj
-mVM
-bXj
-bXj
-pyy
-cZx
-fxq
-oIu
-dyc
-hQp
-gqV
-pyy
 cxM
-pyy
-mhC
+bXj
+bXj
+iqM
+mkZ
+viz
+bEV
+rfN
+jpj
+qtC
+iqM
+bDt
+iqM
+ogI
 bXj
 bXj
 bXj
@@ -76567,20 +76599,20 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 ggx
 ggx
-pyy
-iyc
-moX
-vIf
-dqh
-sgY
-qXt
-tuO
-qXt
-jpj
-mhC
+iqM
+ubm
+fpR
+qkV
+alQ
+dnw
+ojr
+lsD
+ojr
+pVw
+ogI
 wMU
 wMU
 wMU
@@ -76589,7 +76621,7 @@ wMU
 wMU
 wMU
 bbx
-eTN
+gdH
 mqo
 iSG
 iSG
@@ -76794,28 +76826,28 @@ bXj
 bXj
 bXj
 bXj
-mVM
+cxM
 bXj
 bXj
-pyy
-bxy
-emp
-ezj
-kAA
-wDk
-gdy
-pyy
-uvX
-jME
-owN
-erU
-erU
-erU
-erU
-erU
-erU
-owN
-nqU
+iqM
+rbD
+vJv
+rdk
+wpd
+wHB
+cvW
+iqM
+bBM
+tko
+cdl
+rAh
+rAh
+rAh
+rAh
+rAh
+rAh
+cdl
+rqO
 aDK
 tGa
 tkl
@@ -77024,16 +77056,16 @@ bXj
 bXj
 bXj
 bXj
-pyy
-pyy
-pyy
-pyy
-pyy
-pyy
-pyy
-pyy
-pyy
-pyy
+iqM
+iqM
+iqM
+iqM
+iqM
+iqM
+iqM
+iqM
+iqM
+iqM
 bXj
 bXj
 bXj
@@ -77255,7 +77287,7 @@ bXj
 bXj
 ggx
 bXj
-lsD
+epd
 bXj
 bXj
 ggx
@@ -77273,7 +77305,7 @@ ggx
 ggx
 tGa
 uka
-rAn
+ugB
 tGa
 gqk
 bss
@@ -77292,7 +77324,7 @@ dfG
 bfW
 uDR
 bfW
-pzm
+sDk
 qHm
 wKa
 uAv
@@ -77479,14 +77511,14 @@ bXj
 bXj
 bXj
 bXj
-mVM
-mVM
-mVM
-mVM
-mVM
-mVM
-mVM
-mVM
+cxM
+cxM
+cxM
+cxM
+cxM
+cxM
+cxM
+cxM
 bXj
 bXj
 bXj
@@ -77746,7 +77778,7 @@ ykm
 soP
 ykm
 ykm
-ydq
+rUj
 tGa
 wYh
 eaX
@@ -77758,7 +77790,7 @@ nmT
 kEh
 mWi
 fBR
-qfN
+bPA
 rNG
 tbY
 asH
@@ -78250,7 +78282,7 @@ xkx
 xTD
 kKX
 vJR
-doc
+xKI
 aHa
 ygV
 rGC
@@ -78634,7 +78666,7 @@ bXj
 bXj
 bXj
 bXj
-hRR
+kVJ
 bXj
 bXj
 bXj
@@ -78864,7 +78896,7 @@ bXj
 bXj
 bXj
 bXj
-bXj
+nqU
 bXj
 bXj
 tGa
@@ -79384,7 +79416,7 @@ wZs
 pAc
 mqb
 pAc
-avs
+gaj
 hVG
 hVG
 eZi
@@ -79611,7 +79643,7 @@ ees
 pAc
 qSg
 tjX
-rOE
+qAP
 pHb
 arr
 lAx
@@ -80709,7 +80741,7 @@ ujG
 ujG
 ujG
 ujG
-wuw
+tbD
 jDM
 qlP
 ojp
@@ -80736,7 +80768,7 @@ gyi
 qOo
 pRy
 pRy
-tCg
+hcg
 tlL
 rlK
 jfz
@@ -81428,7 +81460,7 @@ cVS
 jLo
 jLo
 jLo
-bVL
+vvB
 hVG
 bkj
 omI
@@ -82313,7 +82345,7 @@ eSD
 jvD
 uqm
 iZD
-bpi
+mbG
 wLG
 xEQ
 fAd
@@ -82531,13 +82563,13 @@ lga
 xon
 rax
 rZu
-mUc
+qyo
 fJm
 xVT
 mst
 wLG
 qDU
-dHw
+oou
 rgI
 wLG
 yeg
@@ -82761,11 +82793,11 @@ jKz
 rZu
 fJm
 jOj
-wVw
+qRp
 sgp
-sYT
+vNm
 fVU
-jhZ
+tht
 fWv
 kSd
 kcc
@@ -83438,9 +83470,9 @@ uMo
 hws
 xon
 ivQ
-lMk
-vKA
-nEw
+xix
+krl
+pjV
 cmo
 wed
 wed
@@ -83450,8 +83482,8 @@ wed
 lNA
 wed
 eGJ
-qLX
-ogV
+dFO
+bHX
 xon
 jwL
 bfH
@@ -83665,7 +83697,7 @@ xon
 xon
 xon
 ivQ
-stV
+pxa
 xon
 xon
 xon
@@ -83892,17 +83924,17 @@ kfX
 kfX
 kfX
 viI
-nDx
+sYT
 xon
 tVI
-koC
+mii
 kcx
 fVL
 sgW
 lFN
-spO
+dqh
 jgJ
-azg
+rsh
 xon
 lbb
 rZu
@@ -84122,19 +84154,19 @@ lmB
 xon
 xon
 teD
-epd
-sjX
-qZR
+fcq
+tPd
+uau
 sgW
-ngh
-qMb
+eYi
+wXw
 gUI
-sHt
+qfN
 xon
 xon
 xon
 xon
-qbD
+unw
 bfH
 iaW
 urt
@@ -84347,16 +84379,16 @@ xon
 nMz
 heM
 xon
-wsA
-uxo
-xBA
-qxZ
-asf
+hlK
+fXW
+eud
+hHD
+gRc
 sgW
-qUy
-xYA
+cZQ
+pfs
 mMx
-kNB
+ilN
 sgW
 eKt
 pPM
@@ -84576,14 +84608,14 @@ iWp
 xon
 mVg
 jpo
-qwG
-rAh
-kVJ
+wnP
+jCW
+ovt
 sgW
-cxy
-mgO
-kOE
-ygS
+kPD
+qUy
+wDk
+iJE
 sgW
 gbf
 tRq
@@ -84799,17 +84831,17 @@ sbH
 gIp
 uKA
 eCT
-fvt
+oIu
 qwM
 dqe
 dqe
 dqe
-win
+owN
 sjD
 sgW
 sgW
 sgW
-dnw
+wVw
 sgW
 sgW
 mrd
@@ -84825,7 +84857,7 @@ daY
 pwn
 eSF
 vMK
-iAn
+xrY
 mzJ
 hVG
 hty
@@ -85031,7 +85063,7 @@ drA
 qcd
 qQV
 aVz
-xrY
+bRZ
 aVz
 lcR
 iBu
@@ -85253,12 +85285,12 @@ uBo
 gNr
 dmj
 dSf
-unw
-unw
+ssO
+ssO
 eNO
 oyl
-hjX
-hjX
+spO
+spO
 cyL
 cyL
 cyL
@@ -85505,7 +85537,7 @@ fXi
 wXp
 tQb
 gKt
-oVU
+qQT
 waR
 auj
 bXj
@@ -86397,7 +86429,7 @@ dSi
 pSn
 ckY
 nfp
-viz
+oAx
 lLD
 hZm
 kuk
@@ -86841,7 +86873,7 @@ aWw
 tqk
 aIW
 dmj
-mNQ
+mVM
 ydH
 dmj
 beS
@@ -86851,7 +86883,7 @@ tGN
 aXU
 nZP
 nfp
-eoM
+iJY
 bNj
 bQD
 sfC
@@ -86862,7 +86894,7 @@ las
 bfH
 jEe
 fXi
-aLO
+qZR
 qHT
 lpm
 fcn
@@ -87775,7 +87807,7 @@ hVG
 hVG
 hVG
 hVG
-xlh
+erU
 oof
 hVG
 hVG
@@ -88435,12 +88467,12 @@ kYD
 hWI
 eBb
 fML
-lLE
+cdF
 eBG
 ehm
 sbl
 cNv
-bEV
+gAi
 rBi
 cNv
 pbC
@@ -88901,7 +88933,7 @@ aNp
 pTy
 ofu
 fCo
-lwZ
+sHt
 vtD
 ubH
 ubH
@@ -89802,14 +89834,14 @@ bXj
 ggx
 bXj
 mYn
-nwh
+jLI
 upq
-eud
+hdi
 mYn
 ajN
 wWS
 fCo
-lwZ
+sHt
 dFm
 sAR
 ubH

--- a/_maps/map_files/CubeStation/Cube.dmm
+++ b/_maps/map_files/CubeStation/Cube.dmm
@@ -211,11 +211,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aez" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -8801,8 +8801,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "eKT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -11424,13 +11424,10 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/stripes/end,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/item/storage/box/beakers/variety{
 	pixel_x = -3
 	},
+/obj/effect/turf_decal/siding/purple/end,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "ghc" = (
@@ -13276,8 +13273,8 @@
 /area/station/hallway/primary/aft)
 "hfG" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "hfK" = (
@@ -14088,8 +14085,8 @@
 /area/station/security/brig)
 "hzl" = (
 /obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "hzp" = (
@@ -14193,14 +14190,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "hCe" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -14483,6 +14477,9 @@
 "hKt" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "hKu" = (
@@ -15467,7 +15464,7 @@
 	dir = 9
 	},
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -16992,8 +16989,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "jha" = (
+/obj/structure/closet{
+	name = "Supplies"
+	},
+/obj/item/vending_refill/custom,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/sales_tagger,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sink/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -17180,10 +17182,10 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "jlV" = (
@@ -17364,13 +17366,10 @@
 /area/station/hallway/primary/starboard)
 "jsb" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "jsd" = (
@@ -18489,10 +18488,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "jWR" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "jWZ" = (
@@ -21492,10 +21494,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -21513,12 +21512,14 @@
 	pixel_y = 30
 	},
 /obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/light/directional/north,
 /obj/item/reagent_containers/dropper,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "lKA" = (
@@ -24142,10 +24143,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/sink/directional/west,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -27881,19 +27880,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "oVu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/stripes/end{
+/obj/effect/turf_decal/siding/purple/end{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -31053,10 +31043,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -31564,20 +31551,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qIn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses{
 	pixel_x = -8;
 	pixel_y = 3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/east{
 	network = list("ss13","rd")
@@ -31587,6 +31565,12 @@
 	},
 /obj/item/storage/pill_bottle/mutadone{
 	pixel_x = 6
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -36527,9 +36511,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -38065,10 +38046,7 @@
 	name = "Genetics Requests Console";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -39418,11 +39396,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "uGH" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -40309,9 +40287,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -65099,7 +65074,7 @@ vQR
 mqz
 cqf
 mDS
-lsO
+xcb
 eOL
 xuJ
 eoB
@@ -66237,7 +66212,7 @@ iJH
 eOL
 feB
 rSB
-uGH
+eKT
 oVu
 lJu
 dKy

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -4998,9 +4998,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cLZ" = (
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/secure_safe/caps_spare,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "cMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22500,6 +22501,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "mmP" = (
@@ -37512,9 +37514,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Bridge West";
 	name = "Bridge West"
-	},
-/obj/structure/secure_safe/caps_spare{
-	pixel_x = -27
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -52655,7 +52654,7 @@ jjW
 jjW
 jjW
 jjW
-cLZ
+jjW
 jjW
 jjW
 jjW
@@ -81062,7 +81061,7 @@ wCP
 jjW
 jjW
 xst
-oKc
+cLZ
 uej
 xIZ
 wvH

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -24993,8 +24993,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lEt" = (
-/obj/structure/closet/crate/bin,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "lEG" = (
@@ -30040,9 +30040,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "nMD" = (
-/obj/structure/secure_safe/caps_spare{
-	pixel_x = 5
-	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "nMM" = (
@@ -46774,7 +46772,6 @@
 "vNW" = (
 /obj/machinery/computer/security/telescreen/rd{
 	dir = 4;
-	network = list("rd","aicore","aiupload","minisat","xeno","test","ordnance");
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -3026,6 +3026,7 @@
 /area/station/maintenance/starboard/fore)
 "bug" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat)
 "bup" = (
@@ -9275,6 +9276,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "AI Chamber North"
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat)
 "emO" = (
@@ -12927,7 +12929,6 @@
 	},
 /area/station/medical/chemistry)
 "fUK" = (
-/obj/structure/cable,
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -12937,6 +12938,7 @@
 	id = "AI"
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/aisat)
 "fUU" = (
@@ -14190,6 +14192,8 @@
 /area/station/security/prison/visit)
 "gBa" = (
 /obj/machinery/porta_turret/ai,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat)
 "gBk" = (
@@ -17592,14 +17596,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "ihg" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ai_core";
-	name = "AI Emergency Shutters"
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/aisat)
 "iho" = (
 /obj/machinery/door/firedoor,
@@ -17992,10 +17991,8 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "iqt" = (
 /obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/light/directional/west,
+/obj/machinery/power/smes/full,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat)
 "iqw" = (
@@ -19036,6 +19033,10 @@
 /obj/structure/sign/directions/security{
 	dir = 8;
 	pixel_y = 40
+	},
+/obj/structure/sign/directions/dorms/directional/north{
+	pixel_y = 24;
+	dir = 8
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -22422,7 +22423,7 @@
 "kuV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/aisat)
 "kuY" = (
@@ -39288,6 +39289,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "AI";
+	name = "AI RC";
+	pixel_y = -30
+	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/aisat)
 "skz" = (
@@ -39862,6 +39871,19 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"syg" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ai_core";
+	name = "AI Emergency Shutters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear/red,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/aisat)
 "syi" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp{
@@ -47066,6 +47088,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat)
 "vSZ" = (
@@ -85361,8 +85384,8 @@ ofc
 toV
 toV
 sIQ
-ihg
-grM
+uSC
+toV
 vFq
 iqt
 nue
@@ -85618,7 +85641,7 @@ bcW
 mxc
 toV
 fUK
-pWa
+syg
 lXs
 vSS
 nax
@@ -85871,12 +85894,12 @@ oLX
 oLX
 uNM
 hOG
-qAk
+ihg
 toV
 toV
 qAk
 uSC
-grM
+toV
 sPg
 vrN
 uSC

--- a/_maps/map_files/IceCubeStation/IceCube.dmm
+++ b/_maps/map_files/IceCubeStation/IceCube.dmm
@@ -2005,14 +2005,15 @@
 /obj/structure/table,
 /obj/item/ai_module/core/full/asimov,
 /obj/item/ai_module/core/freeformcore,
-/obj/machinery/door/window/left/directional/west{
-	name = "Core Modules";
-	req_access = list("captain")
-	},
 /obj/effect/spawner/random/aimodule/harmless,
 /obj/effect/spawner/random/aimodule/neutral,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/item/ai_module/core/full/custom,
+/obj/machinery/door/window/left/directional/west{
+	name = "Core Modules";
+	req_access = list("captain");
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aVs" = (
@@ -4062,14 +4063,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bSn" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Genetics Lab";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "bSC" = (
 /obj/structure/rack,
@@ -9266,10 +9268,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "emo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/turf/open/floor/iron/white,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "emx" = (
 /obj/machinery/porta_turret/ai,
@@ -10066,6 +10079,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
+"eEU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "eFr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -11854,6 +11873,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
+"fvK" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "fvP" = (
 /obj/effect/spawner/random/structure/furniture_parts,
 /turf/open/floor/plating,
@@ -19997,8 +20022,6 @@
 /area/station/medical/virology)
 "jmR" = (
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/dna_infuser,
-/obj/item/infuser_book,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "jna" = (
@@ -23598,7 +23621,8 @@
 "kTV" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "kUb" = (
 /obj/machinery/firealarm/directional/north,
@@ -23902,7 +23926,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "laY" = (
 /obj/structure/cable,
@@ -25238,6 +25263,9 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "lJS" = (
@@ -25330,9 +25358,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "lMG" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "lMI" = (
@@ -25610,6 +25637,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "lSt" = (
@@ -25622,9 +25654,9 @@
 	},
 /area/station/hallway/primary/central/aft)
 "lSF" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
-	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "lSG" = (
@@ -27002,7 +27034,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "mvX" = (
-/obj/structure/sink/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "mwb" = (
@@ -27085,19 +27119,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "myL" = (
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 6;
-	pixel_y = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -5;
-	pixel_y = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "myR" = (
@@ -27383,24 +27410,17 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "mFf" = (
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/item/clothing/gloves/latex{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 8;
-	pixel_y = 1
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/structure/table/glass,
+/obj/structure/sink/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "mFk" = (
@@ -27561,7 +27581,8 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "mIj" = (
 /obj/machinery/light/directional/west,
@@ -29043,6 +29064,9 @@
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -35809,6 +35833,12 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"qEp" = (
+/obj/structure/fence/cut/medium{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qEr" = (
 /obj/machinery/iv_drip,
 /obj/machinery/camera/directional/east{
@@ -38438,7 +38468,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/machinery/dna_infuser,
+/obj/item/infuser_book,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "rMw" = (
@@ -39029,10 +39060,25 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "scv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/white,
+/obj/item/clothing/gloves/latex{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "scI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -39473,9 +39519,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "snJ" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
+/obj/structure/closet{
+	name = "Supplies"
+	},
+/obj/item/vending_refill/custom,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/sales_tagger,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "snR" = (
@@ -40157,9 +40206,7 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
-/obj/machinery/ticket_machine{
-	pixel_y = 32
-	},
+/obj/machinery/ticket_machine/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "sHb" = (
@@ -41660,7 +41707,7 @@
 /area/station/security/brig)
 "twl" = (
 /obj/machinery/light/small/directional/north,
-/obj/machinery/modular_computer/preset/cargochat/science,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/station/science)
 "twv" = (
@@ -41748,6 +41795,7 @@
 /area/station/maintenance/disposal/incinerator)
 "txJ" = (
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/modular_computer/preset/cargochat/science,
 /turf/open/floor/iron/dark,
 /area/station/science)
 "txK" = (
@@ -43163,7 +43211,8 @@
 /area/station/engineering/storage/tech)
 "ufJ" = (
 /obj/machinery/dna_scannernew,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "ufO" = (
 /obj/structure/disposalpipe/segment{
@@ -43609,7 +43658,7 @@
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
 "unN" = (
 /obj/effect/spawner/structure/window,
@@ -45535,7 +45584,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "viy" = (
 /obj/structure/table,
@@ -46729,6 +46778,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
+"vMD" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "vMG" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/chemistry{
@@ -50854,6 +50909,12 @@
 /area/station/service/library/upper)
 "xCz" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "xCR" = (
@@ -51813,6 +51874,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "xWV" = (
@@ -75105,7 +75169,7 @@ aHe
 qfo
 wDW
 ufJ
-uuR
+fvK
 uuR
 uuR
 ohq
@@ -76136,7 +76200,7 @@ rMt
 lMG
 scv
 nqL
-uuR
+eEU
 xoY
 uVP
 tHd
@@ -143202,7 +143266,7 @@ oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -143459,7 +143523,7 @@ oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -143716,7 +143780,7 @@ oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -143973,7 +144037,7 @@ oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -144230,7 +144294,7 @@ oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -144487,7 +144551,7 @@ oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -144738,13 +144802,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -144995,13 +145059,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -145252,13 +145316,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -145509,13 +145573,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+eMf
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+eMf
 oFw
 oFw
 oFw
@@ -145766,13 +145830,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -146023,13 +146087,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -146280,13 +146344,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+sAx
 qNk
 qNk
 qNk
@@ -146537,13 +146601,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -146794,13 +146858,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -147051,13 +147115,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+qEp
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -147308,13 +147372,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -147565,13 +147629,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -147822,13 +147886,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -148079,13 +148143,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -148336,13 +148400,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+sHZ
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+sHZ
 qNk
 qNk
 qNk
@@ -148593,13 +148657,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -148850,13 +148914,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -149107,13 +149171,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -149364,13 +149428,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -149621,13 +149685,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -149878,13 +149942,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -150134,14 +150198,14 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -150390,15 +150454,15 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
 qdO
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -150646,16 +150710,16 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
 oLX
 oLX
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -150903,16 +150967,16 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
 oLX
 hMM
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -151160,16 +151224,16 @@ qNk
 qNk
 qNk
 qNk
-qNk
 aEF
 oLX
 oLX
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+eMf
 qNk
 qNk
 qNk
@@ -151417,16 +151481,16 @@ qNk
 qNk
 qNk
 qNk
-qNk
 wAw
 oLX
 oLX
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -151674,16 +151738,16 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
 oLX
 oLX
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -151932,15 +151996,15 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
 qdO
+vMD
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -152190,14 +152254,14 @@ qNk
 qNk
 qNk
 qNk
-qNk
 oLX
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -152448,13 +152512,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -152705,13 +152769,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -152962,13 +153026,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -153219,13 +153283,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -153476,13 +153540,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -153733,13 +153797,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -153990,13 +154054,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+sHZ
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+sHZ
 qNk
 qNk
 qNk
@@ -154247,13 +154311,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -154504,13 +154568,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -154761,13 +154825,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -155018,13 +155082,13 @@ qNk
 qNk
 qNk
 qNk
-qNk
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-qNk
+hNA
 qNk
 qNk
 qNk
@@ -155275,13 +155339,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -155532,13 +155596,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+qEp
 oFw
 oFw
 oFw
@@ -155789,13 +155853,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+sAx
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -156046,13 +156110,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -156303,13 +156367,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -156560,13 +156624,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+eMf
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+eMf
 oFw
 oFw
 oFw
@@ -156817,13 +156881,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -157074,13 +157138,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -157331,13 +157395,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw
@@ -157588,13 +157652,13 @@ oFw
 oFw
 oFw
 oFw
-oFw
+hNA
 oLX
 oLX
 qxU
 oLX
 oLX
-oFw
+hNA
 oFw
 oFw
 oFw

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -6939,10 +6939,10 @@
 /obj/item/reagent_containers/dropper{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "ceU" = (
@@ -9136,11 +9136,11 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "djh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -16645,8 +16645,8 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "gPm" = (
@@ -22253,7 +22253,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "jWK" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/purple{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
@@ -22677,10 +22677,10 @@
 /area/station/command/heads_quarters/captain)
 "kiS" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "kjc" = (
@@ -22748,6 +22748,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kkD" = (
+/obj/structure/closet{
+	name = "Supplies"
+	},
+/obj/item/vending_refill/custom,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/sales_tagger,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
@@ -24803,12 +24809,12 @@
 /area/station/command/heads_quarters/ce)
 "lst" = (
 /obj/structure/chair/office/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/landmark/start/geneticist,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -25653,11 +25659,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lRP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -27575,7 +27581,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "mXY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -28759,11 +28765,11 @@
 /area/station/medical/medbay/lobby)
 "nHV" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "nHX" = (
@@ -32295,9 +32301,6 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -33152,7 +33155,7 @@
 "qqa" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -52,14 +52,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"aay" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
 "aaA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
@@ -127,7 +119,7 @@
 /area/station/hallway/secondary/entry)
 "aaS" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Arrivals North - East"
+	c_tag = "Arrivals North - West"
 	},
 /obj/structure/sign/warning/pods/directional/north,
 /obj/item/radio/intercom{
@@ -146,7 +138,7 @@
 /area/station/hallway/secondary/entry)
 "aaX" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Arrivals North - West"
+	c_tag = "Arrivals North - East"
 	},
 /obj/structure/sign/warning/pods/directional/north,
 /obj/item/radio/intercom{
@@ -1207,11 +1199,13 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "alf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/turf/open/floor/iron/white/telecomms,
+/area/station/tcommsat/server)
 "alk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1313,9 +1307,6 @@
 /area/station/maintenance/port/fore)
 "alS" = (
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security Checkpoint"
-	},
 /obj/item/crowbar,
 /obj/item/assembly/flash/handheld,
 /obj/item/radio/off{
@@ -2099,16 +2090,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "awg" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/area/station/ai_monitored/turret_protected/ai)
 "aww" = (
 /obj/structure/chair{
 	dir = 4
@@ -2408,15 +2392,11 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
 "aAZ" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "aBl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -2585,12 +2565,17 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "aDa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/simple_animal/bot/secbot/pingsky,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = -30
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Telecommunications Control Room";
+	network = list("ss13","tcomms","minisat")
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/area/station/tcommsat/computer)
 "aDb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
@@ -2605,11 +2590,12 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "aDq" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/tcommsat/server)
 "aDs" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -2720,7 +2706,7 @@
 /area/station/tcommsat/server)
 "aFj" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "East Hallway - Vault"
+	c_tag = "Port Hallway - Vault"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -4720,8 +4706,15 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bgY" = (
-/turf/open/floor/iron,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/structure/cable,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "bgZ" = (
 /obj/machinery/door/window/right/directional/south{
 	req_access = list("xenobiology");
@@ -4954,8 +4947,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bjB" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/turf/open/floor/iron,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bjD" = (
 /obj/item/beacon,
 /turf/open/floor/iron,
@@ -5100,8 +5093,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "blg" = (
-/obj/machinery/ai_slipper{
-	uses = 10
+/obj/machinery/flasher/directional/west{
+	id = "AI"
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
@@ -5137,13 +5130,15 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "bmh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/porta_turret/ai{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Foyer"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bmj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -5174,10 +5169,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bnc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "bnj" = (
 /obj/structure/cable,
 /obj/effect/spawner/atmos_canister/air,
@@ -5194,9 +5188,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "bnv" = (
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "bnw" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/end{
@@ -5236,9 +5229,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "bov" = (
-/obj/machinery/atmospherics/components/tank/air{
-	piping_layer = 4
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "boz" = (
@@ -5383,10 +5376,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bso" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "bss" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/purple{
@@ -5401,12 +5392,6 @@
 	planetary_atmos = 0
 	},
 /area/station/service/hydroponics/garden)
-"bsC" = (
-/obj/structure/transit_tube/station/dispenser/reverse{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bsJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -5495,9 +5480,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "buj" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "North Hallway - East"
-	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -5566,13 +5548,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"bvJ" = (
-/obj/machinery/computer/telecomms/server{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
 "bvX" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/west,
@@ -5760,9 +5735,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "bzY" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -5773,6 +5745,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Access"
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "bAi" = (
@@ -5849,7 +5824,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/directional/south{
-	c_tag = "North Hallway - West"
+	c_tag = "Fore Hallway - Bridge"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -5897,9 +5872,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "bDU" = (
-/obj/machinery/teleport/station,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bEk" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
@@ -6138,12 +6115,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bJG" = (
-/obj/structure/table,
-/obj/item/folder/blue{
-	pixel_y = 2
-	},
-/obj/item/pen,
-/turf/open/floor/iron/dark,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "bJK" = (
 /obj/structure/disposalpipe/segment{
@@ -6185,9 +6158,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bKp" = (
-/obj/machinery/announcement_system,
+/obj/machinery/camera/directional/north{
+	network = list("ss13","qm");
+	c_tag = "Warehouse"
+	},
 /turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/area/station/cargo/warehouse)
 "bKD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -6250,10 +6226,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bMD" = (
-/obj/effect/spawner/random/trash/grime,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Exterior - Fore Starboard";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "bMF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -6285,11 +6263,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "bMY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/camera/directional/south{
+	c_tag = "MiniSat Exterior - Fore";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "bMZ" = (
 /turf/open/misc/dirt{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
@@ -6394,11 +6373,12 @@
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
 "bPq" = (
-/obj/machinery/flasher/directional/west{
-	id = "AI"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
 	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "bPu" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -6415,6 +6395,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"bQf" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "bQj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6424,6 +6412,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"bQm" = (
+/obj/machinery/computer/telecomms/monitor{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "bQE" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -6490,17 +6484,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bSb" = (
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = -30
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Telecommunications Control Room";
-	network = list("ss13","tcomms")
-	},
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bSh" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -6531,10 +6517,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"bTd" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bTf" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -6594,14 +6576,8 @@
 /area/station/engineering/storage/tech)
 "bUb" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/engineering/supermatter/room)
 "bUm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6655,11 +6631,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "bVm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/obj/machinery/porta_turret_construct,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "bVs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -6671,9 +6645,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bVH" = (
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "AI Chamber - Entrance";
+	network = list("minisat")
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
+"bVK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "bVO" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -6705,12 +6694,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bWr" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bWs" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
@@ -6755,11 +6743,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bXN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/machinery/camera/directional/south{
+	c_tag = "Aft Starboard Hallway"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bYm" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -7013,14 +7001,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"cfG" = (
-/obj/machinery/flasher/directional/north{
-	id = "AI"
-	},
-/obj/machinery/holopad/secure,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "cga" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7361,9 +7341,11 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "coI" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/machinery/camera/directional/south{
+	c_tag = "MiniSat Access"
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "coL" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/mapping_helpers/broken_floor,
@@ -7430,9 +7412,12 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/brig)
 "cqf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "cqk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
@@ -7468,7 +7453,7 @@
 /area/station/maintenance/central/lesser)
 "cqR" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "East Hallway North"
+	c_tag = "Port Hallway - Security"
 	},
 /obj/structure/sign/warning/electric_shock{
 	pixel_x = -31
@@ -7517,12 +7502,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "csb" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/tcommsat/server)
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "csP" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /obj/effect/landmark/event_spawn,
@@ -7666,18 +7648,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"cwb" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
 "cwA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
@@ -7709,7 +7679,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
 "cwT" = (
-/obj/structure/sign/departments/telecomms/directional/east,
+/obj/structure/sign/departments/maint/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Antechamber";
+	network = list("minisat")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cxs" = (
@@ -7728,12 +7702,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cxP" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "MiniSat Exterior - Aft Port";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "cyi" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -7807,13 +7780,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cAc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room"
+/obj/machinery/flasher/directional/west{
+	id = "AI"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "cAg" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall"
@@ -7862,11 +7836,10 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "cBX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/circuit,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cBY" = (
 /obj/structure/closet,
@@ -7991,9 +7964,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "cFe" = (
-/obj/structure/girder,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/area/station/ai_monitored/turret_protected/ai)
 "cFf" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -8101,12 +8075,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
-"cHY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "cIB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen"
@@ -8131,8 +8099,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cJZ" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cKb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -8216,10 +8185,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
-"cMA" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "cMG" = (
 /obj/effect/spawner/atmos_canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -8799,7 +8764,7 @@
 /area/station/commons/storage/primary)
 "cZT" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "South Hallway - East";
+	c_tag = "Aft Hallway - Custodial";
 	view_range = 10
 	},
 /turf/open/floor/iron,
@@ -8856,11 +8821,18 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "dbV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat Teleporter";
+	network = list("minisat")
+	},
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
 /turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "dch" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/enzyme{
@@ -8961,8 +8933,9 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/hop)
 "ddV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/ai)
 "ddZ" = (
 /obj/machinery/air_sensor/engine_chamber,
 /turf/open/floor/engine,
@@ -9056,10 +9029,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
-"dgE" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "dgH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -9102,6 +9071,9 @@
 /area/station/engineering/storage)
 "dhn" = (
 /obj/effect/spawner/random/vending/colavend,
+/obj/machinery/camera/directional/north{
+	c_tag = "Departures"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "dho" = (
@@ -9390,16 +9362,9 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "doL" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat Space Access Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "doQ" = (
@@ -9431,10 +9396,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "dpQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/teleport/station,
 /turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "dpR" = (
 /obj/structure/chair{
 	dir = 1
@@ -9480,11 +9444,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "drR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 20
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "drY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -9577,6 +9541,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"duk" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dul" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9666,7 +9637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/south{
-	c_tag = "West Hallway - North"
+	c_tag = "Starboard Hallway - Bridge"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -9970,6 +9941,18 @@
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/station/tcommsat/server)
+"dCK" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "dCM" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron,
@@ -10436,6 +10419,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/pdas,
+/obj/machinery/camera/directional/north{
+	c_tag = "HOPffice"
+	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "dQd" = (
@@ -10714,13 +10700,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "dYa" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/obj/machinery/camera/directional/west{
-	c_tag = "Telecommunications Chamber";
-	network = list("ss13","tcomms")
+/obj/machinery/computer/telecomms/server{
+	dir = 8
 	},
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "dYb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10740,42 +10725,32 @@
 /turf/closed/wall,
 /area/station/science/xenobiology)
 "dYk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/grunge{
-	name = "MiniSat Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "dYo" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "dYM" = (
-/obj/machinery/computer/message_monitor{
-	dir = 8
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Exterior - Aft Starboard";
+	network = list("minisat")
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/turf/open/space/basic,
+/area/space)
 "dYN" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/commons/storage/primary)
 "dYT" = (
-/obj/machinery/turretid{
-	icon_state = "control_stun";
-	name = "AI Chamber turret control";
-	pixel_x = 3;
-	pixel_y = -23
+/obj/machinery/atmospherics/components/tank/air{
+	piping_layer = 4
 	},
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "dYV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -11115,8 +11090,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "eeU" = (
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/structure/tank_frame,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "efo" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -11178,6 +11154,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"ehA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "ehE" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/stripes/box,
@@ -11856,7 +11838,7 @@
 /area/station/maintenance/fore)
 "eyf" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "North Hallway - Intersection"
+	c_tag = "Fore Hallway - Intersection"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -11877,7 +11859,7 @@
 /area/station/hallway/primary/fore)
 "eyn" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/full,
+/obj/machinery/power/smes/super/full,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "eyp" = (
@@ -12003,6 +11985,10 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"ezN" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "ezO" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -13063,6 +13049,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
+"eXK" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "eXO" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -13089,16 +13085,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"eYs" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
 "eYz" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/structure/cable,
@@ -13256,7 +13242,7 @@
 /area/station/engineering/engine_smes)
 "fdj" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "East Hallway - Chapel"
+	c_tag = "Port Hallway - Chapel"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
@@ -13431,6 +13417,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Fore Hallway - Kitchen"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fjb" = (
@@ -13549,11 +13538,10 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "flJ" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/random/trash/garbage,
+/obj/structure/sign/warning/secure_area/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "flO" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
@@ -13685,12 +13673,10 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fpn" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "MiniSat Exterior - Starboard Fore";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "fpr" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "HFR"
@@ -13713,10 +13699,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
 "fpx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fpA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -14172,9 +14157,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "fBI" = (
-/obj/machinery/teleport/hub,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "fBN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/turf_decal/siding/yellow{
@@ -14314,11 +14301,14 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "fFa" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
-"fFc" = (
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "fFr" = (
@@ -14359,14 +14349,14 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "fGh" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fGs" = (
@@ -14929,6 +14919,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/station/hallway/primary/fore)
+"fVH" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "fWh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -15027,6 +15021,12 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"fZk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fZm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -15052,6 +15052,10 @@
 /obj/machinery/airalarm/directional/east,
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","qm");
+	c_tag = "Mining - Processing"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "gai" = (
@@ -15449,6 +15453,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"glt" = (
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat Foyer";
+	network = list("minisat")
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "glw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15747,10 +15760,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gsb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/camera/directional/east{
+	c_tag = "MiniSat Exterior - Aft Port";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "gsc" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
@@ -15785,9 +15800,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
 "gsw" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "gsB" = (
 /obj/effect/landmark/start/mime,
 /turf/open/floor/carpet/orange,
@@ -15971,17 +15985,10 @@
 /turf/closed/indestructible/riveted,
 /area/station/science/ordnance/bomb)
 "gxm" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/transit_tube,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "gxy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16795,6 +16802,10 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "gTM" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay Suppplies";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "gUl" = (
@@ -16844,12 +16855,10 @@
 	},
 /area/station/science/ordnance/bomb)
 "gWb" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "AI Chamber - Fore";
-	network = list("aicore")
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "gWJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -16859,15 +16868,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "gWN" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gWT" = (
@@ -17024,6 +17033,10 @@
 "hbL" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	network = list("ss13","qm");
+	c_tag = "Mining - Dock"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -17329,6 +17342,10 @@
 /area/station/maintenance/starboard/aft)
 "hkJ" = (
 /obj/machinery/netpod,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","qm");
+	c_tag = "Bitrunning Den"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "hli" = (
@@ -17784,18 +17801,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hxJ" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "MiniSat Foyer";
-	network = list("minisat")
-	},
-/obj/item/radio/intercom/directional/north{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Private Channel"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/ai_monitored/turret_protected/ai)
 "hxQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/east{
@@ -18716,6 +18725,10 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
+/obj/machinery/camera/directional/west{
+	c_tag = "CMO Office";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
 "hWR" = (
@@ -19078,7 +19091,7 @@
 /area/station/science/robotics/mechbay)
 "ijp" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Escape Hallway North"
+	c_tag = "Aft Hallway - Bar"
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -19323,12 +19336,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "iqG" = (
-/obj/structure/transit_tube/station/dispenser/reverse/flipped{
-	dir = 4
+/obj/machinery/camera/directional/north{
+	c_tag = "AI Chamber - Core";
+	network = list("aicore")
 	},
-/obj/machinery/light/directional/east,
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/ai_monitored/turret_protected/ai)
 "iqQ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -19506,12 +19523,16 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "iwK" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "iwL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -19786,11 +19807,10 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
 "iEz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/east,
+/obj/effect/spawner/random/trash/grime,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "iEE" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
@@ -19848,12 +19868,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "iFL" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "MiniSat Exterior - Fore";
-	network = list("minisat")
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "iGo" = (
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -20083,14 +20102,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/misc/grass/jungle,
 /area/station/security/prison)
-"iMB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cyborg,
-/obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "iNP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -20837,6 +20848,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"jlU" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "jlW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -20884,6 +20900,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"jnm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "jnr" = (
 /obj/machinery/netpod,
 /obj/item/radio/intercom/directional/east,
@@ -21217,16 +21242,12 @@
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
 "jxO" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat Space Access Airlock"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "jxY" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
@@ -22168,13 +22189,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"jVf" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "AI Chamber - Core";
-	network = list("aicore")
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "jVg" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -22244,6 +22258,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"jWL" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "jWU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22505,6 +22523,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"kcw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "kcP" = (
 /obj/structure/cable,
 /obj/structure/closet/emcloset,
@@ -22815,12 +22838,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"koB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "koS" = (
 /obj/structure/sign/warning/secure_area/directional/north,
 /obj/machinery/space_heater,
@@ -23371,10 +23388,14 @@
 /area/station/medical/medbay/lobby)
 "kCw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/area/station/ai_monitored/turret_protected/ai)
 "kCL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -24162,7 +24183,11 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "kZn" = (
-/obj/effect/landmark/start/ai/secondary,
+/obj/machinery/flasher/directional/north{
+	id = "AI"
+	},
+/obj/machinery/holopad/secure,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "kZr" = (
@@ -24799,7 +24824,7 @@
 /area/station/hallway/primary/starboard)
 "lsU" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "West Hallway - Robotics"
+	c_tag = "Starboard Hallway - Robotics"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -24888,11 +24913,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
 "lwA" = (
-/obj/structure/showcase/cyborg/old{
-	pixel_y = 20
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/item/wallframe/camera,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "lxs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -25187,7 +25210,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lEa" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "lEb" = (
@@ -25227,6 +25251,10 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"lFR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "lGa" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Storage"
@@ -25516,10 +25544,12 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "lPb" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Exterior - Aft";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "lPi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -25683,14 +25713,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"lTf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "lUf" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lUs" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "lUt" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/checker,
@@ -26094,6 +26129,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
+"mgX" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "mhj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27176,14 +27215,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "mNz" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "mNZ" = (
@@ -27392,10 +27431,10 @@
 /turf/open/floor/iron,
 /area/station/medical/surgery)
 "mTy" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "mTO" = (
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/grass,
@@ -27732,9 +27771,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "nff" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "nfg" = (
 /turf/closed/wall/r_wall,
@@ -27966,6 +28008,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"njm" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "njD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/chair,
@@ -28694,6 +28741,9 @@
 /area/station/hallway/secondary/entry)
 "nGX" = (
 /obj/machinery/computer/slot_machine,
+/obj/machinery/camera/directional/north{
+	network = list("ss13","bar")
+	},
 /turf/open/floor/stone,
 /area/station/service/bar)
 "nHc" = (
@@ -29106,13 +29156,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"nTa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
 "nTk" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/light/directional/north,
@@ -29322,6 +29365,14 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet)
+"ocH" = (
+/obj/structure/table,
+/obj/item/folder/blue{
+	pixel_y = 2
+	},
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "ocI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -29558,16 +29609,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "okN" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/effect/landmark/start/ai/secondary,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "okR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "olb" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -29817,6 +29865,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
+"oqN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "ore" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -30230,12 +30284,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"oDA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "oDV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dressing Room"
@@ -30433,15 +30481,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"oJp" = (
-/obj/machinery/flasher/directional/west{
-	id = "AI"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "oJC" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30762,13 +30801,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "oTT" = (
-/obj/structure/sign/departments/maint/directional/west,
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "MiniSat Waste"
+/obj/machinery/computer/message_monitor{
+	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/tcommsat/computer)
 "oUw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30827,6 +30865,16 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"oXO" = (
+/obj/item/radio/intercom/directional/north{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "oXQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -30881,14 +30929,17 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "paT" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Foyer"
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/tcommsat/computer)
 "paV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31147,12 +31198,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
-"pjc" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
 "pjd" = (
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -31290,15 +31335,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "pmk" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/porta_turret/ai{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/ai_monitored/turret_protected/ai)
 "pmw" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -32404,10 +32447,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "pUc" = (
-/obj/effect/spawner/random/trash/garbage,
-/obj/structure/sign/warning/secure_area/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "pUd" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
@@ -32564,13 +32607,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "pXC" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "pXO" = (
 /obj/structure/chair{
 	dir = 4
@@ -32591,9 +32629,10 @@
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
 "pYb" = (
-/obj/item/wallframe/camera,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/machinery/porta_turret/ai,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "pYn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -32677,10 +32716,14 @@
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
 "qaP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/obj/machinery/turretid{
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = 3;
+	pixel_y = -23
+	},
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "qbc" = (
 /obj/machinery/computer/cargo/request{
 	dir = 1
@@ -33374,9 +33417,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qxG" = (
-/obj/structure/sign/departments/telecomms/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "qxT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33398,10 +33441,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qya" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "qyb" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -33638,6 +33681,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
+"qDS" = (
+/obj/structure/sign/departments/telecomms/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "qEq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
 	dir = 4
@@ -34199,9 +34246,13 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "qUI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/machinery/telecomms/receiver/preset_left,
+/obj/machinery/camera/directional/west{
+	c_tag = "Telecommunications Chamber";
+	network = list("ss13","tcomms","minisat")
+	},
+/turf/open/floor/iron/white/telecomms,
+/area/station/tcommsat/server)
 "qUN" = (
 /obj/vehicle/ridden/janicart,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -34489,8 +34540,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rcy" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
+/obj/structure/sign/departments/telecomms/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "rcF" = (
@@ -34575,7 +34625,7 @@
 /area/station/hallway/primary/starboard)
 "rfW" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Escape Hallway South"
+	c_tag = "Aft Hallway"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -35086,8 +35136,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rxt" = (
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/item/radio/intercom/directional/north{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "rxE" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -35100,8 +35157,9 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "rxJ" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/announcement_system,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "rxM" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -35467,12 +35525,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "rLh" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "MiniSat Exterior - Aft";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/computer/teleporter,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "rLv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36247,13 +36302,10 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "siv" = (
-/obj/structure/sign/departments/maint/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "MiniSat Antechamber";
-	network = list("minisat")
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/structure/closet/firecloset,
+/obj/structure/sign/departments/aisat/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "siB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -36321,10 +36373,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/cytology)
 "sjE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/machinery/teleport/hub,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "sjG" = (
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/hello_world,
@@ -36423,9 +36474,8 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "smQ" = (
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "smY" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -36556,7 +36606,7 @@
 /area/station/commons/dorms)
 "srT" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "South Hallway - Intersection"
+	c_tag = "Aft Hallway - Intersection"
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -37307,12 +37357,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"sMd" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
 "sMp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -37342,9 +37386,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "sOf" = (
-/obj/machinery/porta_turret_construct,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/machinery/camera/directional/north{
+	c_tag = "Aft Hallway - Bar"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "sOj" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -37638,14 +37684,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tbm" = (
-/obj/item/radio/intercom/directional/north{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Private Channel"
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "tby" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Turbine Room";
@@ -37910,6 +37953,11 @@
 /obj/effect/turf_decal/siding/red/end,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"tgQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "tgV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38144,6 +38192,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"tna" = (
+/obj/structure/sign/departments/maint/directional/west,
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	name = "MiniSat Waste"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "tnd" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=8";
@@ -38299,7 +38356,7 @@
 /area/station/cargo/office)
 "tqy" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "West Hallway - South"
+	c_tag = "Starboard Hallway - Mech Bay"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/end,
 /turf/open/floor/iron,
@@ -38372,11 +38429,25 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "tsn" = (
-/obj/structure/frame/computer{
-	dir = 4
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
 	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	listening = 0;
+	name = "Common Channel"
+	},
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "tsu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38585,12 +38656,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "txG" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "MiniSat Exterior - Fore Starboard";
-	network = list("minisat")
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "txT" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/carpet/black,
@@ -39302,20 +39376,25 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "tSf" = (
-/obj/machinery/computer/telecomms/monitor{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/cyborg,
+/obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
+"tSu" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
-"tSu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/ai_slipper{
-	uses = 10
+/obj/machinery/camera/directional/east{
+	c_tag = "Starboard Hallway"
 	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "tSF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -39339,12 +39418,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "tSO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/area/station/tcommsat/computer)
 "tSV" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
 	dir = 4
@@ -39484,7 +39559,7 @@
 	dir = 9
 	},
 /obj/machinery/camera/directional/south{
-	c_tag = "East Hallway South"
+	c_tag = "Port Hallway - Engineering Entrance"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -39640,6 +39715,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"tYt" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "tZe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -39728,13 +39809,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "ubP" = (
-/obj/machinery/requests_console/auto_name/directional/west,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "AI Chamber - Fore";
+	network = list("aicore")
+	},
 /turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/ai)
 "ucd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39805,10 +39885,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "udF" = (
-/obj/structure/closet/firecloset,
-/obj/structure/sign/departments/aisat/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "udH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40194,11 +40279,16 @@
 /area/station/medical/virology)
 "unL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/grunge{
+	name = "MiniSat Maintenance"
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "unW" = (
 /obj/machinery/computer/records/medical{
 	dir = 1
@@ -40569,6 +40659,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "uAp" = (
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "uAs" = (
@@ -41070,11 +41161,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"uRQ" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
 "uRS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -41159,6 +41245,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/station/command/heads_quarters/rd)
 "uVs" = (
@@ -41233,10 +41320,18 @@
 	},
 /area/station/engineering/atmos)
 "uXI" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "uXP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41329,7 +41424,7 @@
 /area/station/science/lab)
 "vaN" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "East Hallway - Engineering"
+	c_tag = "Port Hallway - Engineering Desk"
 	},
 /obj/structure/noticeboard{
 	dir = 8;
@@ -41709,6 +41804,10 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics South South";
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "vmC" = (
@@ -41724,6 +41823,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"vnn" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "vnK" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
@@ -41776,9 +41881,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vqY" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/requests_console/auto_name/directional/west,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "vrf" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/closet/emcloset{
@@ -42033,14 +42142,12 @@
 /turf/open/floor/plating,
 /area/station/service/theater)
 "vyR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Exterior - Starboard Fore";
+	network = list("minisat")
 	},
-/obj/machinery/camera/directional/north{
-	network = list("ss13","bar")
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar)
+/turf/open/space/basic,
+/area/space)
 "vAe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -42358,9 +42465,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
 "vJY" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "South Hallway West"
-	},
 /obj/structure/chair{
 	dir = 4
 	},
@@ -42883,15 +42987,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wal" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Chamber"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "wap" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /obj/effect/turf_decal/siding/dark_red{
@@ -42922,6 +43023,11 @@
 /obj/structure/flora/bush/jungle/c/style_random,
 /turf/open/floor/grass,
 /area/station/ai_monitored/command/storage/eva)
+"wbo" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "wbp" = (
 /obj/machinery/plate_press,
 /turf/open/floor/iron/dark,
@@ -42940,12 +43046,10 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "wbQ" = (
-/obj/item/radio/intercom/directional/south{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Private Channel"
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "wbV" = (
@@ -43030,7 +43134,7 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "wec" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -43277,8 +43381,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "wlm" = (
-/obj/machinery/porta_turret/ai,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "wlo" = (
@@ -43298,6 +43403,10 @@
 "wlx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/siding/dark_red,
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Midwest";
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wlB" = (
@@ -43845,11 +43954,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wzW" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "wAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -44260,9 +44370,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "wOt" = (
-/obj/machinery/computer/teleporter,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "wOz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/siding/red{
@@ -44284,12 +44394,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wPc" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "wPw" = (
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
@@ -44439,11 +44548,8 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit)
 "wTf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "wTx" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
@@ -44460,12 +44566,6 @@
 /obj/item/mmi,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"wTJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "wTL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/entertainment/drugs,
@@ -44739,8 +44839,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xcK" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "xcO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44961,18 +45065,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "xhP" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "MiniSat Teleporter";
-	network = list("minisat")
-	},
-/obj/item/radio/intercom/directional/south{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Private Channel"
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/teleporter)
+/area/station/tcommsat/computer)
 "xhT" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -45031,6 +45128,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/station/command/heads_quarters/rd)
 "xjv" = (
@@ -45097,10 +45195,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "xkj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "xkx" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -45318,10 +45416,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"xqV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "xrg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -45352,6 +45446,9 @@
 	},
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/grape,
+/obj/machinery/camera/directional/south{
+	c_tag = "Garden"
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "xse" = (
@@ -45553,32 +45650,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xxJ" = (
-/obj/item/radio/intercom/directional/south{
-	freerange = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Private Channel"
-	},
-/obj/effect/landmark/start/ai,
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	listening = 0;
-	name = "Common Channel"
-	},
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel"
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "xxU" = (
 /obj/structure/sign/plaques/kiddie{
 	pixel_x = 32
-	},
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "AI Upload East";
-	network = list("aiupload")
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -46194,9 +46274,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "xPV" = (
-/obj/structure/tank_frame,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/maint)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "xPZ" = (
 /turf/closed/wall,
 /area/station/science/genetics)
@@ -46309,12 +46392,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "xSP" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "MiniSat Exterior - Aft Starboard";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "xSQ" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/structure/cable,
@@ -61209,7 +61289,7 @@ xbl
 rbU
 aXp
 bMC
-okN
+duk
 xEh
 agW
 aiO
@@ -61468,7 +61548,7 @@ aYx
 bJr
 xve
 cPv
-coI
+bUb
 aiO
 auR
 aCD
@@ -61724,8 +61804,8 @@ rbU
 bam
 bJr
 eZi
-cAc
-coI
+bQf
+bUb
 dwG
 xRq
 dVt
@@ -72540,7 +72620,7 @@ qNu
 wxk
 eyq
 tuj
-jQe
+bKp
 wlp
 rHf
 lxW
@@ -76580,7 +76660,7 @@ ady
 wnZ
 wnZ
 aez
-afD
+afW
 pKR
 gfQ
 gfQ
@@ -80254,7 +80334,7 @@ nGX
 ogW
 gTv
 vVO
-vyR
+eLy
 gRG
 gRG
 rSg
@@ -80692,7 +80772,7 @@ adB
 adQ
 wnZ
 afa
-afW
+afD
 pKR
 gfQ
 gfQ
@@ -82302,7 +82382,7 @@ dfs
 wPB
 wPB
 wPB
-vTt
+sOf
 oBk
 eto
 fyM
@@ -87187,7 +87267,7 @@ xbT
 xbT
 xbT
 uCO
-xbT
+bXN
 gep
 gep
 otB
@@ -87671,7 +87751,7 @@ wqb
 wqb
 wqb
 wqb
-wqb
+tSu
 wqb
 kka
 kuF
@@ -88652,7 +88732,7 @@ gfQ
 gfQ
 gfQ
 fsz
-cxP
+gsb
 gfQ
 gfQ
 gfQ
@@ -88891,26 +88971,26 @@ gfQ
 gfQ
 gfQ
 gfQ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
+lUs
+lUs
+lUs
+lUs
+lUs
 gfQ
 gfQ
 gfQ
 gfQ
-xcK
-xcK
-xcK
-xcK
-xcK
-xcK
-xcK
-xcK
-xcK
-xcK
-xcK
+smQ
+smQ
+smQ
+smQ
+smQ
+smQ
+smQ
+smQ
+smQ
+smQ
+smQ
 gfQ
 gfQ
 gfQ
@@ -89145,30 +89225,30 @@ gfQ
 gfQ
 gfQ
 gfQ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-xcK
-xcK
-rxt
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+smQ
+smQ
+bso
 nbj
-uRQ
-sOf
-xcK
-rxt
-bnv
-tsn
-rxt
-xcK
-xcK
+jlU
+bVm
+smQ
+bso
+ezN
+vnn
+bso
+smQ
+smQ
 gfQ
 gfQ
 gfQ
@@ -89401,31 +89481,31 @@ gfQ
 tWC
 gfQ
 gfQ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-aDq
-kZn
+lUs
+lUs
+lUs
+lUs
+lUs
+cBX
+okN
 iwE
-cJZ
-cJZ
-cJZ
-cJZ
-xcK
-bov
+lUs
+lUs
+lUs
+lUs
+smQ
+dYT
 wOL
-okR
-okR
-nTa
+xSP
+xSP
+xxJ
 qrN
 cpl
 uUy
 uUy
 uUy
 nbj
-xcK
+smQ
 gfQ
 gfQ
 gfQ
@@ -89658,31 +89738,31 @@ gfQ
 tWC
 fsz
 fsz
-cJZ
-cJZ
-fFa
+lUs
+lUs
+awg
 hZE
 iwE
 mjV
-bnc
+kcw
 pHn
 pHn
-xkj
+wlm
 rbn
-cJZ
-xcK
+lUs
+smQ
 vNQ
 llI
 mKM
 bzI
-bXN
-cFe
+bov
+wOt
 eyn
-iwK
-sMd
-bXN
-pYb
-xcK
+cqf
+tYt
+bov
+lwA
+smQ
 gfQ
 gfQ
 gfQ
@@ -89915,8 +89995,8 @@ gfQ
 tWC
 gfQ
 gfQ
-cJZ
-cJZ
+lUs
+lUs
 iwE
 jZp
 jZp
@@ -89926,20 +90006,20 @@ pOW
 pOW
 pOW
 deY
-cJZ
-xcK
-xPV
+lUs
+smQ
+eeU
 fuX
-xcK
-xcK
+smQ
+smQ
 hEP
-xcK
-xcK
-xcK
-xcK
-dYk
-xcK
-xcK
+smQ
+smQ
+smQ
+smQ
+unL
+smQ
+smQ
 gfQ
 gfQ
 gfQ
@@ -89958,10 +90038,10 @@ yeH
 oHu
 yeH
 vKx
-udF
+siv
 qOK
-qxG
-pUc
+qDS
+flJ
 ucx
 jhN
 yeH
@@ -90171,33 +90251,33 @@ gfQ
 gfQ
 tWC
 gfQ
-cJZ
-cJZ
-cJZ
+lUs
+lUs
+lUs
 iwE
 jZp
-cJZ
-cJZ
-pXC
-cJZ
-cJZ
-bso
+lUs
+lUs
+nff
+lUs
+lUs
+fpn
 pHn
-cJZ
-cJZ
-cJZ
-rxJ
-rxJ
+lUs
+lUs
+lUs
+wTf
+wTf
 exJ
-kCw
-siv
-rxJ
+wPc
+cwT
+wTf
 toK
-wzW
-koB
-oTT
-wTJ
-pjc
+rxt
+lTf
+tna
+doL
+bWr
 gfQ
 gfQ
 gfQ
@@ -90428,34 +90508,34 @@ gfQ
 gfQ
 tWC
 gfQ
-cJZ
-cJZ
+lUs
+lUs
 iwE
 iwE
 jZp
-cJZ
-qya
+lUs
+pUc
 pOW
-dYT
-cJZ
+qaP
+lUs
 pOW
 bko
-nff
-oJp
-wbQ
-rxJ
-uAp
-uAp
-kCw
-unL
-rcy
-toK
-lwA
+cFe
+cAc
+bVH
 wTf
-oDA
-fpx
-fpx
-fpx
+pXC
+pXC
+wPc
+fBI
+lEa
+toK
+drR
+mTy
+bDU
+gWb
+gWb
+gWb
 fsz
 fsz
 fsz
@@ -90469,10 +90549,10 @@ fsz
 fsz
 fsz
 fsz
-qUI
-qUI
-qUI
-bgY
+bSb
+bSb
+bSb
+bjB
 bFh
 cmP
 toK
@@ -90684,35 +90764,35 @@ gfQ
 gfQ
 gfQ
 tWC
-iFL
-cJZ
-cJZ
-fFa
+bMY
+lUs
+lUs
+awg
 iwE
-blg
-cJZ
-cfG
-blg
-xxJ
-cJZ
-wlm
-tSu
-bUb
-drR
-drR
-wal
-bMY
-bMY
-aDa
-alf
-uAp
-paT
-eeU
-iMB
-cMA
+xkj
+lUs
+kZn
+xkj
+tsn
+lUs
+pYb
+jnm
+kCw
+cxP
+cxP
+bgY
 aAZ
-eeU
-pmk
+aAZ
+wzW
+xPV
+bnc
+bmh
+jWL
+tSf
+gsw
+udF
+gsw
+eXK
 bKo
 bKo
 bKo
@@ -90726,9 +90806,9 @@ bKo
 bKo
 bKo
 bKo
-jxO
-bTd
-doL
+iwK
+mgX
+uXI
 bhA
 bIn
 coH
@@ -90942,34 +91022,34 @@ gfQ
 gfQ
 tWC
 gfQ
-cJZ
-cJZ
+lUs
+lUs
 iwE
 iwE
 jZp
-cJZ
-jVf
+lUs
+iqG
 jZp
-cJZ
-cJZ
-gsw
+lUs
+lUs
+bJG
 bko
-nff
-cBX
+cFe
+jxO
 jZp
-rxJ
-tbm
-lEa
-kCw
-cwT
-lPb
-toK
-lwA
 wTf
-cHY
-fpx
-fpx
-fpx
+oXO
+uAp
+wPc
+rcy
+njm
+toK
+drR
+tbm
+oqN
+gWb
+gWb
+gWb
 fsz
 fsz
 fsz
@@ -90983,12 +91063,12 @@ fsz
 fsz
 fsz
 fsz
-qUI
-qUI
-qUI
-bgY
-bgY
-bgY
+bSb
+bSb
+bSb
+bjB
+bjB
+coI
 toK
 gfQ
 sAi
@@ -91199,52 +91279,52 @@ gfQ
 gfQ
 tWC
 gfQ
-cJZ
-cJZ
-cJZ
+lUs
+lUs
+lUs
 iwE
 jZp
-cJZ
-cJZ
-wPc
-cJZ
-cJZ
-vqY
+lUs
+lUs
+wbQ
+lUs
+lUs
+qxG
 pHn
-cJZ
+lUs
 xsI
 xsI
 xsI
 xsI
 xsI
-gxm
+paT
 xsI
 xsI
 toK
-hxJ
-wTf
-iqG
-sjE
-bVH
-bVH
-smQ
-bVH
-bVH
-bVH
-bVH
-bVH
-smQ
-bVH
-bVH
-bVH
-bVH
-bVH
-smQ
-bVH
-bVH
-sjE
+glt
+tbm
+xcK
+gxm
+cJZ
+cJZ
+okR
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+okR
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+okR
+cJZ
+cJZ
+gxm
 bjT
-bsC
+iFL
 toK
 toK
 gfQ
@@ -91457,32 +91537,32 @@ gfQ
 tWC
 gfQ
 gfQ
-cJZ
-cJZ
-gWb
+lUs
+lUs
+ubP
 jZp
 jZp
-bPq
+blg
 jZp
 jZp
 jZp
 jZp
 pHn
-cJZ
-xsI
 lUs
 xsI
-flJ
-ubP
-dbV
-bKp
+fVH
 xsI
-bjB
-bjB
-awg
-bjB
-bjB
-rLh
+xhP
+vqY
+ehA
+rxJ
+xsI
+bnv
+bnv
+fFa
+bnv
+bnv
+lPb
 gfQ
 gfQ
 gfQ
@@ -91714,31 +91794,31 @@ gfQ
 tWC
 fsz
 fsz
-cJZ
-cJZ
-fFa
-dgE
+lUs
+lUs
+awg
+fpx
 iwE
-xqV
-gsb
-pHn
-pHn
-iEz
-bmh
-cJZ
-xsI
 ddV
-bWr
-cqf
-dpQ
-eYs
-bSb
+hxJ
+pHn
+pHn
+fZk
+pmk
+lUs
 xsI
-wOt
-qaP
-bVm
-uXI
-bjB
+tSO
+bPq
+lFR
+tgQ
+txG
+aDa
+xsI
+rLh
+qya
+bVK
+dYk
+bnv
 gfQ
 gfQ
 gfQ
@@ -91971,31 +92051,31 @@ gfQ
 tWC
 gfQ
 gfQ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-bJG
-kZn
+lUs
+lUs
+lUs
+lUs
+lUs
+ocH
+okN
 iwE
-cJZ
-cJZ
-cJZ
-cJZ
+lUs
+lUs
+lUs
+lUs
 xsI
-ddV
-oSz
-cwb
-tSf
-bvJ
-dYM
-xsI
-bDU
-bMD
 tSO
-mTy
-bjB
+oSz
+dCK
+bQm
+dYa
+oTT
+xsI
+dpQ
+iEz
+wal
+wbo
+bnv
 gfQ
 gfQ
 gfQ
@@ -92229,30 +92309,30 @@ gfQ
 gfQ
 gfQ
 gfQ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
+lUs
 vlZ
 vlZ
 vlZ
 vlZ
+aDq
+nbM
+nbM
+nbM
+nbM
+nbM
+vlZ
+sjE
 csb
-nbM
-nbM
-nbM
-nbM
-nbM
-vlZ
-fBI
-fFc
-xhP
-bjB
-bjB
+dbV
+bnv
+bnv
 gfQ
 gfQ
 gfQ
@@ -92489,15 +92569,15 @@ gfQ
 gfQ
 gfQ
 gfQ
-cJZ
-cJZ
-cJZ
-cJZ
-cJZ
+lUs
+lUs
+lUs
+lUs
+lUs
 vlZ
 dnt
 aEn
-dYa
+qUI
 cLg
 lEq
 cLg
@@ -92505,10 +92585,10 @@ rRc
 rAY
 ear
 vlZ
-bjB
-bjB
-bjB
-bjB
+bnv
+bnv
+bnv
+bnv
 gfQ
 gfQ
 gfQ
@@ -92746,7 +92826,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-txG
+bMD
 gfQ
 fsz
 gfQ
@@ -92764,7 +92844,7 @@ eat
 vlZ
 gfQ
 gfQ
-xSP
+dYM
 fsz
 gfQ
 gfQ
@@ -93531,7 +93611,7 @@ ccr
 cMe
 auw
 dCj
-aay
+alf
 vlZ
 fsz
 tWC
@@ -94298,7 +94378,7 @@ gfQ
 fsz
 gfQ
 gfQ
-fpn
+vyR
 gfQ
 gfQ
 fsz

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -52,6 +52,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"aay" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/turf/open/floor/iron/white/telecomms,
+/area/station/tcommsat/server)
 "aaA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
@@ -364,6 +372,7 @@
 /area/station/maintenance/port/fore)
 "adj" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "adk" = (
@@ -816,6 +825,7 @@
 /area/station/security/prison/safe)
 "agW" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "agX" = (
@@ -1197,9 +1207,11 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "alf" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "alk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2087,9 +2099,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "awg" = (
-/obj/machinery/computer/telecomms/server,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "aww" = (
 /obj/structure/chair{
 	dir = 4
@@ -2389,12 +2408,15 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
 "aAZ" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 4;
-	network = "tcommsat"
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
 	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "aBl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -2563,11 +2585,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "aDa" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/secbot/pingsky,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "aDb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
@@ -2582,8 +2605,11 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "aDq" = (
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "aDs" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -3419,11 +3445,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "aPS" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/left/directional/west{
-	name = "High-Risk Modules";
-	req_access = list("captain")
-	},
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
 /obj/item/ai_module/supplied/oxygen{
@@ -3698,7 +3719,6 @@
 /area/station/commons/storage/primary)
 "aUf" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aUg" = (
@@ -4700,9 +4720,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bgY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bgZ" = (
 /obj/machinery/door/window/right/directional/south{
 	req_access = list("xenobiology");
@@ -4802,8 +4821,9 @@
 /area/station/hallway/primary/fore)
 "bhA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bhD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -4934,14 +4954,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bjB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "bjD" = (
 /obj/item/beacon,
 /turf/open/floor/iron,
@@ -5008,21 +5022,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bjT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecomms External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/transit_tube,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bkg" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -5038,8 +5040,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "bko" = (
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bkr" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/power/port_gen/pacman,
@@ -5096,15 +5100,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "blg" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bln" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5137,21 +5137,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "bmh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecomms External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "bmj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -5182,12 +5174,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bnc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "bnj" = (
 /obj/structure/cable,
 /obj/effect/spawner/atmos_canister/air,
@@ -5204,12 +5194,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "bnv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "bnw" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/end{
@@ -5249,12 +5236,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "bov" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Telecommunications Chamber";
-	network = list("ss13","engine")
+/obj/machinery/atmospherics/components/tank/air{
+	piping_layer = 4
 	},
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "boz" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -5397,8 +5383,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bso" = (
-/turf/closed/wall,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bss" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/purple{
@@ -5413,6 +5401,12 @@
 	planetary_atmos = 0
 	},
 /area/station/service/hydroponics/garden)
+"bsC" = (
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bsJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -5572,6 +5566,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"bvJ" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "bvX" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/west,
@@ -5727,9 +5728,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bzI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "bzK" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -5761,7 +5763,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -5769,9 +5770,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination/minisat_access_tcomms,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bAi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -5894,9 +5897,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "bDU" = (
-/obj/machinery/light/broken/directional/north,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/teleport/station,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "bEk" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
@@ -5985,8 +5988,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/minisat_access_tcomms_ai,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bFp" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -6066,14 +6070,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "bIn" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bIx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6135,15 +6138,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bJG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/structure/table,
+/obj/item/folder/blue{
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "bJK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6184,14 +6185,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bKp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/announcement_system,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "bKD" = (
 /obj/structure/cable,
@@ -6255,12 +6250,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bMD" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/random/trash/grime,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "bMF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -6292,15 +6285,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "bMY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "bMZ" = (
 /turf/open/misc/dirt{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
@@ -6405,20 +6394,11 @@
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
 "bPq" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications"
+/obj/machinery/flasher/directional/west{
+	id = "AI"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/navigate_destination/tcomms,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "bPu" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -6510,14 +6490,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bSb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/camera/directional/south{
+	c_tag = "Telecommunications Control Room";
+	network = list("ss13","tcomms")
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "bSh" = (
 /obj/structure/closet/secure_closet/chemical,
@@ -6549,6 +6531,10 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"bTd" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bTf" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -6607,9 +6593,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "bUb" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "bUm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6663,9 +6655,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "bVm" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "bVs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -6677,16 +6671,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bVH" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/computer)
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bVO" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -6718,12 +6705,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bWr" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "bWs" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
@@ -6768,12 +6755,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bXN" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "bYm" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -7027,6 +7013,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"cfG" = (
+/obj/machinery/flasher/directional/north{
+	id = "AI"
+	},
+/obj/machinery/holopad/secure,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "cga" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7272,7 +7266,7 @@
 "cmP" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "cnf" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
@@ -7363,17 +7357,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "coH" = (
-/turf/closed/wall,
-/area/station/tcommsat/computer)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "coI" = (
-/obj/structure/transit_tube/station/reverse{
-	dir = 1
-	},
-/obj/structure/transit_tube_pod{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "coL" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/mapping_helpers/broken_floor,
@@ -7390,8 +7380,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "cpl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "cpq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -7437,8 +7430,8 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/brig)
 "cqf" = (
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "cqk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
@@ -7524,10 +7517,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "csb" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/server)
 "csP" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /obj/effect/landmark/event_spawn,
@@ -7671,6 +7666,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"cwb" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "cwA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
@@ -7702,10 +7709,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
 "cwT" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/sign/departments/telecomms/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "cxs" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office"
@@ -7722,10 +7728,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cxP" = (
-/obj/structure/transit_tube/crossing/horizontal,
-/obj/structure/lattice/catwalk,
+/obj/machinery/camera/directional/east{
+	c_tag = "MiniSat Exterior - Aft Port";
+	network = list("minisat")
+	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cyi" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -7799,10 +7807,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cAc" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "cAg" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall"
@@ -7851,9 +7862,12 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "cBX" = (
-/obj/structure/transit_tube/station/reverse/flipped,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "cBY" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -7977,15 +7991,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "cFe" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Control Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "cFf" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -8093,6 +8101,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
+"cHY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "cIB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen"
@@ -8117,9 +8131,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cJZ" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "cKb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -8203,6 +8216,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"cMA" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "cMG" = (
 /obj/effect/spawner/atmos_canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -8237,6 +8254,7 @@
 "cNw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/incident_display/delam/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "cNI" = (
@@ -8838,11 +8856,10 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "dbV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "dch" = (
 /obj/structure/table/reinforced,
@@ -8944,10 +8961,7 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/hop)
 "ddV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "ddZ" = (
 /obj/machinery/air_sensor/engine_chamber,
@@ -8982,9 +8996,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "deY" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/south{
+	c_tag = "AI Chamber - Aft";
+	network = list("aicore")
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "dfd" = (
 /obj/effect/landmark/navigate_destination/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -9037,6 +9056,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
+"dgE" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "dgH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -9367,12 +9390,18 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "doL" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock"
 	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "doQ" = (
 /obj/machinery/door/window/right/directional/south{
 	name = "Containment Pen #1";
@@ -9402,13 +9431,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "dpQ" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "dpR" = (
 /obj/structure/chair{
@@ -9455,9 +9480,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "drR" = (
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "drY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -9545,8 +9572,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dtO" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "dul" = (
@@ -9664,6 +9692,7 @@
 /area/station/science/research)
 "dwt" = (
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "dwG" = (
@@ -10685,10 +10714,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "dYa" = (
-/obj/structure/table,
-/obj/item/multitool,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/telecomms/receiver/preset_left,
+/obj/machinery/camera/directional/west{
+	c_tag = "Telecommunications Chamber";
+	network = list("ss13","tcomms")
+	},
+/turf/open/floor/iron/white/telecomms,
+/area/station/tcommsat/server)
 "dYb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10708,32 +10740,42 @@
 /turf/closed/wall,
 /area/station/science/xenobiology)
 "dYk" = (
-/obj/structure/rack,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/radio/off,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/grunge{
+	name = "MiniSat Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "dYo" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "dYM" = (
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = -30
+/obj/machinery/computer/message_monitor{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "dYN" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/commons/storage/primary)
 "dYT" = (
-/obj/machinery/announcement_system,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/turretid{
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = 3;
+	pixel_y = -23
+	},
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/ai)
 "dYV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -11073,11 +11115,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "eeU" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/telecomms,
-/area/station/tcommsat/server)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "efo" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -11785,10 +11824,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "exJ" = (
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/item/stack/sheet/iron/five,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/computer/security/telescreen/minisat{
+	pixel_y = 30
+	},
+/obj/structure/table,
+/obj/item/phone{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "exK" = (
 /obj/machinery/air_sensor/carbon_tank,
 /obj/effect/turf_decal/siding/dark{
@@ -11828,9 +11876,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "eyn" = (
-/obj/effect/spawner/random/trash/grime,
+/obj/structure/cable,
+/obj/machinery/power/smes/full,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "eyp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -13040,6 +13089,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"eYs" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "eYz" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/structure/cable,
@@ -13059,6 +13118,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eZk" = (
@@ -13489,9 +13549,11 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "flJ" = (
-/obj/item/light/tube/broken,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/light/directional/west,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "flO" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
@@ -13623,9 +13685,12 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fpn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Exterior - Starboard Fore";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "fpr" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "HFR"
@@ -13648,10 +13713,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
 "fpx" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "fpA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -13918,9 +13983,9 @@
 /turf/closed/wall,
 /area/station/medical/psychology)
 "fuX" = (
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/aimodule,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "fvv" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/north,
@@ -14107,9 +14172,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "fBI" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/teleport/hub,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "fBN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/turf_decal/siding/yellow{
@@ -14249,9 +14314,13 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "fFa" = (
-/obj/item/stack/sheet/cardboard,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
+"fFc" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "fFr" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -15678,9 +15747,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gsb" = (
-/obj/effect/spawner/random/aimodule,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "gsc" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
@@ -15715,9 +15785,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
 "gsw" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "gsB" = (
 /obj/effect/landmark/start/mime,
 /turf/open/floor/carpet/orange,
@@ -15901,9 +15971,17 @@
 /turf/closed/indestructible/riveted,
 /area/station/science/ordnance/bomb)
 "gxm" = (
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "gxy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16766,9 +16844,12 @@
 	},
 /area/station/science/ordnance/bomb)
 "gWb" = (
-/obj/item/stack/sheet/iron,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/camera/directional/north{
+	c_tag = "AI Chamber - Fore";
+	network = list("aicore")
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "gWJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -17703,18 +17784,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hxJ" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Telecomms Admin";
-	name = "Telecomms RC";
-	pixel_y = 30
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat Foyer";
+	network = list("minisat")
 	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/item/book/manual/wiki/tcomms,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/item/radio/intercom/directional/north{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "hxQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/east{
@@ -18019,10 +18100,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hEP" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/grunge{
+	name = "MiniSat Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "hER" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18717,8 +18805,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hZE" = (
-/turf/open/floor/circuit,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "hZV" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -19234,9 +19323,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "iqG" = (
-/obj/structure/broken_flooring/singular,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "iqQ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -19405,9 +19497,8 @@
 /turf/open/floor/plating,
 /area/station/security/prison)
 "iwE" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "iwF" = (
 /obj/machinery/modular_computer/preset/command{
 	dir = 1
@@ -19415,9 +19506,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "iwK" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "iwL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -19692,10 +19786,11 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
 "iEz" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "iEE" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
@@ -19753,21 +19848,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "iFL" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/camera/directional/south{
+	c_tag = "MiniSat Exterior - Fore";
+	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecomms External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/turf/open/space/basic,
+/area/space)
 "iGo" = (
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -19997,6 +20083,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/misc/grass/jungle,
 /area/station/security/prison)
+"iMB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/cyborg,
+/obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "iNP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -20568,9 +20662,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jeK" = (
-/obj/structure/frame/machine,
-/turf/open/floor/circuit,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/camera/directional/east{
+	c_tag = "MiniSat Exterior - Fore Port";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "jfh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21120,14 +21217,16 @@
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
 "jxO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "jxY" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
@@ -22069,6 +22168,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"jVf" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "AI Chamber - Core";
+	network = list("aicore")
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "jVg" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -22262,9 +22368,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "jZp" = (
-/obj/item/wallframe/airalarm,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "jZG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22710,6 +22815,12 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"koB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "koS" = (
 /obj/structure/sign/warning/secure_area/directional/north,
 /obj/machinery/space_heater,
@@ -23259,9 +23370,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "kCw" = (
-/obj/machinery/light/built/directional/west,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "kCL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -24049,10 +24162,9 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "kZn" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/effect/landmark/start/ai/secondary,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "kZr" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/south,
@@ -24454,9 +24566,9 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "llI" = (
-/obj/structure/grille/broken,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "lmo" = (
 /obj/structure/chair{
 	dir = 8
@@ -24776,9 +24888,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
 "lwA" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 20
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "lxs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -25073,9 +25187,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lEa" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "lEb" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -25402,10 +25516,10 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "lPb" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/item/stack/sheet/iron,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "lPi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -25574,9 +25688,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lUs" = (
-/obj/structure/firelock_frame/heavy,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "lUt" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/checker,
@@ -26122,9 +26236,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "mjV" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "mkx" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/decoration/carpet,
@@ -26886,10 +27000,11 @@
 /turf/open/floor/iron/checker,
 /area/station/command/heads_quarters/ce)
 "mIq" = (
-/obj/machinery/light/dim/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/flasher/directional/east{
+	id = "AI"
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "mII" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -27012,9 +27127,9 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "mKM" = (
-/obj/item/wallframe/apc,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "mKS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -27277,14 +27392,10 @@
 /turf/open/floor/iron,
 /area/station/medical/surgery)
 "mTy" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/recharge_station,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "mTO" = (
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/grass,
@@ -27511,9 +27622,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "nbj" = (
-/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "nbl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27621,9 +27732,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "nff" = (
-/obj/machinery/porta_turret_construct,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/ai)
 "nfg" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage)
@@ -28994,6 +29106,13 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"nTa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "nTk" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/light/directional/north,
@@ -29439,15 +29558,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "okN" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
-"okR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/engineering/main)
+"okR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "olb" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -30110,6 +30230,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"oDA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "oDV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dressing Room"
@@ -30307,6 +30433,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"oJp" = (
+/obj/machinery/flasher/directional/west{
+	id = "AI"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "oJC" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30627,10 +30762,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "oTT" = (
-/obj/structure/table_frame,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/sign/departments/maint/directional/west,
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	name = "MiniSat Waste"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "oUw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30743,12 +30881,14 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "paT" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Foyer"
 	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "paV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31007,6 +31147,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"pjc" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "pjd" = (
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -31144,9 +31290,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "pmk" = (
-/obj/structure/broken_flooring/pile/directional/south,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "pmw" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -31883,9 +32035,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "pHn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "pHC" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -32106,10 +32259,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "pOW" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pPi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/table/glass,
@@ -32252,9 +32404,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "pUc" = (
-/obj/machinery/computer/message_monitor,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/random/trash/garbage,
+/obj/structure/sign/warning/secure_area/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "pUd" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
@@ -32411,9 +32564,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "pXC" = (
-/obj/machinery/light/broken/directional/south,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pXO" = (
 /obj/structure/chair{
 	dir = 4
@@ -32434,9 +32591,9 @@
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
 "pYb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/item/wallframe/camera,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "pYn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -32520,10 +32677,10 @@
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
 "qaP" = (
-/obj/structure/door_assembly/door_assembly_hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "qbc" = (
 /obj/machinery/computer/cargo/request{
 	dir = 1
@@ -32992,9 +33149,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qrN" = (
-/obj/item/stack/rods/two,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "qse" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -33214,10 +33374,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qxG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/mapping_helpers/damaged_window,
+/obj/structure/sign/departments/telecomms/directional/east,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/maintenance/fore)
 "qxT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33239,10 +33398,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qya" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "qyb" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -34040,9 +34199,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "qUI" = (
-/obj/machinery/light/built/directional/south,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "qUN" = (
 /obj/vehicle/ridden/janicart,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -34282,9 +34441,13 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "rbn" = (
-/obj/structure/tank_frame,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "rbC" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 4
@@ -34326,9 +34489,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rcy" = (
-/obj/item/wallframe/camera,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "rcF" = (
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
@@ -34482,6 +34646,7 @@
 /area/station/security/prison/safe)
 "rlu" = (
 /obj/machinery/digital_clock/directional/north,
+/obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "rlv" = (
@@ -34921,9 +35086,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rxt" = (
-/obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "rxE" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -34936,9 +35100,8 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "rxJ" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "rxM" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -35304,21 +35467,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "rLh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Exterior - Aft";
+	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecomms External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/turf/open/space/basic,
+/area/space)
 "rLv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36093,8 +36247,13 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "siv" = (
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/sign/departments/maint/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Antechamber";
+	network = list("minisat")
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "siB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -36162,10 +36321,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/cytology)
 "sjE" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden/crude,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/transit_tube,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "sjG" = (
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/hello_world,
@@ -36264,9 +36423,9 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "smQ" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "smY" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -37148,6 +37307,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"sMd" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "sMp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -37177,11 +37342,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "sOf" = (
-/obj/structure/frame/computer{
-	dir = 4
-	},
+/obj/machinery/porta_turret_construct,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "sOj" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -37475,9 +37638,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tbm" = (
-/obj/effect/spawner/random/trash/bacteria,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/item/radio/intercom/directional/north{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "tby" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Turbine Room";
@@ -38062,9 +38230,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "toK" = (
-/obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/station/tcommsat/computer)
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "toL" = (
 /obj/docking_port/stationary/public_mining_dock{
 	dir = 8
@@ -38205,9 +38372,11 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "tsn" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "tsu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38416,10 +38585,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "txG" = (
-/obj/machinery/light/small/broken/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Exterior - Fore Starboard";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "txT" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/carpet/black,
@@ -39131,13 +39302,20 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "tSf" = (
-/obj/effect/spawner/random/structure/closet_empty,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/computer/telecomms/monitor{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "tSu" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "tSF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -39161,9 +39339,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "tSO" = (
-/obj/structure/broken_flooring/corner/directional/west,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "tSV" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
 	dir = 4
@@ -39547,9 +39728,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "ubP" = (
-/obj/structure/broken_flooring/side/directional/east,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/requests_console/auto_name/directional/west,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "ucd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39620,12 +39805,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "udF" = (
-/obj/structure/secure_safe/caps_spare{
-	pixel_x = 5;
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/station/command/bridge)
+/obj/structure/closet/firecloset,
+/obj/structure/sign/departments/aisat/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "udH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40010,10 +40193,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "unL" = (
-/obj/structure/table_frame,
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "unW" = (
 /obj/machinery/computer/records/medical{
 	dir = 1
@@ -40384,11 +40569,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "uAp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "uAs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40888,6 +41070,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"uRQ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "uRS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -40949,10 +41136,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "uUy" = (
-/obj/effect/mapping_helpers/broken_machine,
-/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "uUE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -41046,11 +41233,10 @@
 	},
 /area/station/engineering/atmos)
 "uXI" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/vacuum/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "uXP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41590,17 +41776,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vqY" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/camera/directional/west{
-	c_tag = "Bridge Entry East"
-	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "vrf" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/closet/emcloset{
@@ -42329,9 +42507,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/exam_room)
 "vNQ" = (
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "vNY" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -42705,9 +42883,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wal" = (
-/obj/item/stack/rods,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/hallway)
 "wap" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /obj/effect/turf_decal/siding/dark_red{
@@ -42756,9 +42940,14 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "wbQ" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "wbV" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/conveyor{
@@ -43088,10 +43277,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "wlm" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/porta_turret/ai,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "wlo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -43656,8 +43845,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wzW" = (
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "wAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -44068,9 +44260,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "wOt" = (
-/obj/item/light/bulb/broken,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/computer/teleporter,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "wOz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/siding/red{
@@ -44080,9 +44272,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wOL" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/components/binary/pump/on/general/visible/layer4{
+	name = "MiniSat Air"
+	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "wPa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -44090,9 +44284,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wPc" = (
-/obj/item/light/tube/broken,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "wPw" = (
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
@@ -44242,9 +44439,11 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit)
 "wTf" = (
-/obj/machinery/light/small/built/directional/east,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "wTx" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
@@ -44261,6 +44460,12 @@
 /obj/item/mmi,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"wTJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "wTL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/entertainment/drugs,
@@ -44534,9 +44739,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xcK" = (
-/obj/structure/broken_flooring,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "xcO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44757,11 +44961,18 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "xhP" = (
-/obj/structure/frame/computer{
-	dir = 1
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "MiniSat Teleporter";
+	network = list("minisat")
 	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/teleporter)
 "xhT" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -44886,15 +45097,11 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "xkj" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "xkx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -45111,13 +45318,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"xqV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "xrg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "xrP" = (
-/obj/structure/closet/crate/coffin,
 /obj/machinery/camera/directional/north{
 	c_tag = "Bridge Upload Room";
 	network = list("aiupload")
@@ -45343,15 +45553,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xxJ" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	listening = 0;
+	name = "Common Channel"
 	},
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "xxU" = (
 /obj/structure/sign/plaques/kiddie{
 	pixel_x = 32
@@ -45859,11 +46079,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "xMg" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/left/directional/west{
-	name = "Core Modules";
-	req_access = list("captain")
-	},
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/neutral,
 /obj/effect/spawner/random/aimodule/harmless,
@@ -45979,10 +46194,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "xPV" = (
-/obj/structure/table,
-/obj/effect/spawner/random/engineering/tool,
+/obj/structure/tank_frame,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "xPZ" = (
 /turf/closed/wall,
 /area/station/science/genetics)
@@ -46095,9 +46309,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "xSP" = (
-/obj/machinery/light/broken/directional/west,
-/turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/satellite)
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat Exterior - Aft Starboard";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "xSQ" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/structure/cable,
@@ -60992,7 +61209,7 @@ xbl
 rbU
 aXp
 bMC
-afo
+okN
 xEh
 agW
 aiO
@@ -61251,7 +61468,7 @@ aYx
 bJr
 xve
 cPv
-dwG
+coI
 aiO
 auR
 aCD
@@ -61507,8 +61724,8 @@ rbU
 bam
 bJr
 eZi
-cSO
-dwG
+cAc
+coI
 dwG
 xRq
 dVt
@@ -84604,7 +84821,7 @@ aJc
 lGF
 trZ
 ahA
-udF
+cNn
 qHO
 xWX
 vtm
@@ -86359,10 +86576,10 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-fsz
-fsz
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -86617,22 +86834,22 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
-fsz
 gfQ
-bko
 gfQ
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bko
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -86871,26 +87088,26 @@ gfQ
 gfQ
 gfQ
 gfQ
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-fuX
-cJZ
-sOf
-cpl
-bzI
-gWb
-bso
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87127,27 +87344,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-bso
-bso
-fBI
-gsw
-cpl
-bzI
-kCw
-bso
-oTT
-cpl
-bzI
-bso
-cpl
-fpx
-tsn
-cpl
-xhP
-cpl
-bso
-fsz
-fsz
 gfQ
 gfQ
 gfQ
@@ -87157,7 +87353,28 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87383,36 +87600,36 @@ gfQ
 gfQ
 gfQ
 gfQ
-bso
-bso
-drR
-cJZ
-bzI
-cpl
-deY
-cpl
-cJZ
-cpl
-fuX
-cpl
-bso
-rcy
-bso
-txG
-cJZ
-cpl
-fBI
-bso
-gfQ
-fsz
-fsz
-fsz
-fsz
 gfQ
 gfQ
-fsz
-fsz
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87640,28 +87857,28 @@ gfQ
 gfQ
 gfQ
 gfQ
-bso
-bzI
-eyn
-cpl
-gxm
-hZE
-cpl
-bzI
-hZE
-bzI
-cpl
-fBI
-bso
-bso
-bso
-bso
-wOL
-bso
-bso
-bso
-fsz
-bko
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -87896,30 +88113,30 @@ gfQ
 gfQ
 gfQ
 gfQ
-bko
-bso
-bDU
-flJ
-bzI
-cpl
-iqG
-iEz
-bso
-nbj
-hZE
-bzI
-bso
-bso
-fBI
-bso
-tSf
-siv
-xPV
-bso
-bso
-bso
-sjE
-bso
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -88154,31 +88371,31 @@ gfQ
 gfQ
 gfQ
 gfQ
-bso
-bso
-cpl
-cpl
-fBI
-iwE
-cpl
-kZn
-bso
-gWb
-cpl
-pYb
-pHn
-rxt
-pYb
-pHn
-cpl
-wal
-xSP
-bso
-uXI
-iwE
-bso
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+gfQ
+gfQ
+gfQ
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
 gfQ
 gfQ
 gfQ
@@ -88409,33 +88626,33 @@ gfQ
 gfQ
 gfQ
 gfQ
-bko
-fsz
-bso
-cpl
-fpn
-fFa
-bso
-bzI
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 jeK
-llI
-eyn
-hZE
-pHn
-qaP
-iqG
-siv
-sjE
-tSu
-wPc
-ubP
-cJZ
-wlm
-bUb
-qUI
-bso
+gfQ
+fsz
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+cxP
 gfQ
 gfQ
 gfQ
@@ -88666,34 +88883,34 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-fsz
-bso
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 cJZ
-cpl
-bzI
-bso
-iwK
-hZE
-lPb
-fBI
-cpl
-iwE
-qxG
-qya
-bzI
-pYb
-tSO
-cpl
-bzI
-siv
-bso
-wbQ
+cJZ
+cJZ
+cJZ
+cJZ
+gfQ
+gfQ
+gfQ
+gfQ
 xcK
-bso
-gfQ
-fsz
-gfQ
+xcK
+xcK
+xcK
+xcK
+xcK
+xcK
+xcK
+xcK
+xcK
+xcK
 gfQ
 gfQ
 gfQ
@@ -88923,35 +89140,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
-bso
-deY
-fpx
-cpl
-gWb
-bso
-bzI
-lUs
-nff
-pmk
-bzI
-bso
-bso
-bso
-bso
-unL
-bzI
+gfQ
+gfQ
+gfQ
+gfQ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+xcK
+xcK
+rxt
 nbj
-bso
-bso
-bso
-bso
-bso
-bso
-gfQ
-fsz
-gfQ
+uRQ
+sOf
+xcK
+rxt
+bnv
+tsn
+rxt
+xcK
+xcK
 gfQ
 gfQ
 gfQ
@@ -89180,35 +89397,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
-bso
-cpl
-fuX
-fBI
-bzI
-cpl
-cpl
-cpl
-bzI
-cpl
-pXC
-bso
-bso
-bso
-bso
-bso
+tWC
+gfQ
+gfQ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+aDq
+kZn
+iwE
+cJZ
+cJZ
+cJZ
+cJZ
+xcK
+bov
 wOL
-bso
-bso
-bso
+okR
+okR
+nTa
 qrN
 cpl
 uUy
-bso
-gfQ
-fsz
-gfQ
+uUy
+uUy
+nbj
+xcK
 gfQ
 gfQ
 gfQ
@@ -89437,35 +89654,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
-bso
-bso
-bzI
-cpl
-cpl
+tWC
+fsz
+fsz
+cJZ
+cJZ
+fFa
 hZE
 iwE
 mjV
-cpl
+bnc
 pHn
-bzI
-bso
+pHn
+xkj
 rbn
-bzI
-bso
+cJZ
+xcK
 vNQ
 llI
 mKM
 bzI
-bso
-bzI
+bXN
+cFe
 eyn
-bzI
-bso
-fsz
-gfQ
-gfQ
+iwK
+sMd
+bXN
+pYb
+xcK
 gfQ
 gfQ
 gfQ
@@ -89695,34 +89912,34 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-fsz
-bso
-bso
-gsb
-cpl
-bso
+tWC
+gfQ
+gfQ
+cJZ
+cJZ
+iwE
+jZp
 jZp
 mIq
-bso
 pOW
-cpl
-bso
+pOW
+pOW
+pOW
 deY
 cJZ
-smQ
-bzI
+xcK
+xPV
 fuX
-iwE
-cpl
+xcK
+xcK
 hEP
-nbj
-bzI
-tbm
-bso
-fsz
-gfQ
-gfQ
+xcK
+xcK
+xcK
+xcK
+dYk
+xcK
+xcK
 gfQ
 gfQ
 gfQ
@@ -89741,10 +89958,10 @@ yeH
 oHu
 yeH
 vKx
-lgt
+udF
 qOK
-xII
-qQZ
+qxG
+pUc
 ucx
 jhN
 yeH
@@ -89952,35 +90169,35 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
 gfQ
-gfQ
-gfQ
+cJZ
+cJZ
+cJZ
+iwE
+jZp
+cJZ
+cJZ
+pXC
+cJZ
+cJZ
 bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-wOt
-wTf
-bzI
-exJ
-bso
-cpl
+pHn
+cJZ
+cJZ
+cJZ
 rxJ
-bso
-bso
-gfQ
-gfQ
-gfQ
-gfQ
+rxJ
+exJ
+kCw
+siv
+rxJ
+toK
+wzW
+koB
+oTT
+wTJ
+pjc
 gfQ
 gfQ
 gfQ
@@ -89997,11 +90214,11 @@ gfQ
 yeH
 yeH
 yeH
-xsI
+toK
 toK
 bzY
-xsI
-xsI
+toK
+toK
 yeH
 yeH
 yeH
@@ -90209,56 +90426,56 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+cJZ
+cJZ
+iwE
+iwE
+jZp
+cJZ
+qya
+pOW
+dYT
+cJZ
+pOW
 bko
-gfQ
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-bso
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+nff
+oJp
+wbQ
+rxJ
+uAp
+uAp
+kCw
+unL
+rcy
+toK
+lwA
+wTf
+oDA
+fpx
+fpx
+fpx
 fsz
-xsI
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+qUI
+qUI
+qUI
 bgY
 bFh
 cmP
-xsI
+toK
 gfQ
 yeH
 vKx
@@ -90466,56 +90683,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-fsz
-bko
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-xsI
+tWC
+iFL
+cJZ
+cJZ
+fFa
+iwE
+blg
+cJZ
+cfG
+blg
+xxJ
+cJZ
+wlm
+tSu
+bUb
+drR
+drR
+wal
+bMY
+bMY
+aDa
+alf
+uAp
+paT
+eeU
+iMB
+cMA
+aAZ
+eeU
+pmk
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+bKo
+jxO
+bTd
+doL
 bhA
 bIn
 coH
-xsI
+toK
 gfQ
 yeH
 vKx
@@ -90723,56 +90940,56 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+cJZ
+cJZ
+iwE
+iwE
+jZp
+cJZ
+jVf
+jZp
+cJZ
+cJZ
+gsw
+bko
+nff
+cBX
+jZp
+rxJ
+tbm
+lEa
+kCw
+cwT
+lPb
+toK
+lwA
+wTf
+cHY
+fpx
+fpx
+fpx
 fsz
 fsz
 fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-xsI
-bjB
-bJG
-coI
-xsI
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+qUI
+qUI
+qUI
+bgY
+bgY
+bgY
+toK
 gfQ
 sAi
 sAi
@@ -90980,56 +91197,56 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
+cJZ
+cJZ
+cJZ
+iwE
+jZp
+cJZ
+cJZ
+wPc
+cJZ
+cJZ
+vqY
+pHn
+cJZ
 xsI
+xsI
+xsI
+xsI
+xsI
+gxm
+xsI
+xsI
+toK
+hxJ
+wTf
+iqG
+sjE
+bVH
+bVH
+smQ
+bVH
+bVH
+bVH
+bVH
+bVH
+smQ
+bVH
+bVH
+bVH
+bVH
+bVH
+smQ
+bVH
+bVH
+sjE
 bjT
-oSz
-cqf
-xsI
+bsC
+toK
+toK
 gfQ
 gfQ
 gfQ
@@ -91237,56 +91454,56 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
+cJZ
+cJZ
+gWb
+jZp
+jZp
+bPq
+jZp
+jZp
+jZp
+jZp
+pHn
+cJZ
 xsI
-blg
-oSz
-csb
+lUs
+xsI
+flJ
+ubP
+dbV
+bKp
+xsI
+bjB
+bjB
+awg
+bjB
+bjB
+rLh
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 toK
+toK
+toK
+toK
+gfQ
 gfQ
 gfQ
 gfQ
@@ -91494,55 +91711,55 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+tWC
 fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-toK
+cJZ
+cJZ
+fFa
+dgE
+iwE
+xqV
+gsb
+pHn
+pHn
+iEz
 bmh
-oSz
-cwT
+cJZ
+xsI
+ddV
+bWr
+cqf
+dpQ
+eYs
+bSb
+xsI
+wOt
+qaP
+bVm
+uXI
+bjB
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -91751,6 +91968,34 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
+gfQ
+gfQ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+bJG
+kZn
+iwE
+cJZ
+cJZ
+cJZ
+cJZ
+xsI
+ddV
+oSz
+cwb
+tSf
+bvJ
+dYM
+xsI
+bDU
+bMD
+tSO
+mTy
+bjB
 gfQ
 gfQ
 gfQ
@@ -91772,34 +92017,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xkj
-bKo
-cwT
 gfQ
 gfQ
 gfQ
@@ -92012,6 +92229,30 @@ gfQ
 gfQ
 gfQ
 gfQ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+vlZ
+vlZ
+vlZ
+vlZ
+csb
+nbM
+nbM
+nbM
+nbM
+nbM
+vlZ
+fBI
+fFc
+xhP
+bjB
+bjB
 gfQ
 gfQ
 gfQ
@@ -92033,30 +92274,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xkj
-bKo
-cwT
 gfQ
 gfQ
 gfQ
@@ -92272,6 +92489,26 @@ gfQ
 gfQ
 gfQ
 gfQ
+cJZ
+cJZ
+cJZ
+cJZ
+cJZ
+vlZ
+dnt
+aEn
+dYa
+cLg
+lEq
+cLg
+rRc
+rAY
+ear
+vlZ
+bjB
+bjB
+bjB
+bjB
 gfQ
 gfQ
 gfQ
@@ -92294,26 +92531,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xkj
-bKo
-cxP
 gfQ
 gfQ
 gfQ
@@ -92529,6 +92746,26 @@ gfQ
 gfQ
 gfQ
 gfQ
+txG
+gfQ
+fsz
+gfQ
+gfQ
+vlZ
+rYm
+aFb
+tRF
+fRe
+qNI
+fRe
+eGE
+dvQ
+eat
+vlZ
+gfQ
+gfQ
+xSP
+fsz
 gfQ
 gfQ
 gfQ
@@ -92551,26 +92788,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xkj
-bKo
-cwT
 gfQ
 gfQ
 gfQ
@@ -92786,6 +93003,26 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
+tWC
+tWC
+tWC
+gfQ
+vlZ
+alu
+uFD
+wCu
+bqM
+lEq
+cLq
+wCu
+dwW
+eaF
+vlZ
+gfQ
+tWC
+tWC
+tWC
 gfQ
 gfQ
 gfQ
@@ -92808,26 +93045,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xkj
-bKo
-cxP
 gfQ
 gfQ
 gfQ
@@ -93046,6 +93263,21 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
+gfQ
+vlZ
+anC
+qxp
+wCu
+ptT
+lEq
+cLC
+wCu
+dxM
+eaS
+vlZ
+gfQ
+tWC
 gfQ
 gfQ
 gfQ
@@ -93070,21 +93302,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-toK
-rLh
-oSz
-cwT
 gfQ
 gfQ
 gfQ
@@ -93303,6 +93520,21 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
+fsz
+vlZ
+apd
+hWR
+kwM
+xFV
+ccr
+cMe
+auw
+dCj
+aay
+vlZ
+fsz
+tWC
 gfQ
 gfQ
 gfQ
@@ -93328,21 +93560,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xsI
-blg
-oSz
-cAc
-toK
 gfQ
 gfQ
 gfQ
@@ -93560,6 +93777,21 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
+gfQ
+vlZ
+oRt
+aFc
+aYt
+xio
+poM
+cMG
+dex
+dEg
+efo
+vlZ
+gfQ
+tWC
 gfQ
 gfQ
 gfQ
@@ -93585,21 +93817,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xsI
-iFL
-oSz
-cqf
-xsI
 gfQ
 gfQ
 gfQ
@@ -93819,6 +94036,17 @@ gfQ
 gfQ
 gfQ
 gfQ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
+vlZ
 gfQ
 gfQ
 gfQ
@@ -93846,17 +94074,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xsI
-jxO
-bKp
-cBX
-xsI
 gfQ
 gfQ
 gfQ
@@ -94078,13 +94295,13 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
+fpn
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -94109,11 +94326,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-xsI
-bnc
-bMD
-coH
-xsI
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -94334,6 +94551,15 @@ gfQ
 gfQ
 gfQ
 gfQ
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
+tWC
 gfQ
 gfQ
 gfQ
@@ -94363,17 +94589,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
-xsI
-lwA
-bMY
-cmP
-xsI
-gfQ
-gfQ
-fsz
 gfQ
 eGL
 eGL
@@ -94618,21 +94835,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-tWC
-tWC
-tWC
-fsz
-xsI
-toK
-bPq
-toK
-xsI
-fsz
-tWC
-tWC
-tWC
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 eGL
 eOw
 eOw
@@ -94875,20 +95092,20 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 fsz
-gfQ
-fsz
-fsz
-xsI
-bMY
-xsI
-fsz
-fsz
-gfQ
-fsz
-gfQ
 fsz
 eGL
 eOw
@@ -95132,21 +95349,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-xsI
-xsI
-xsI
-xsI
-xsI
-bMY
-xsI
-xsI
-xsI
-xsI
-xsI
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
 eGL
 wcL
 qNz
@@ -95389,21 +95606,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-xsI
-lEa
-aAZ
-paT
-vqY
-bSb
-cFe
-dbV
-doL
-dYa
-xsI
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+fsz
+gfQ
 eGL
 eGL
 eGL
@@ -95645,22 +95862,22 @@ gfQ
 gfQ
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 fsz
-tWC
 fsz
-xsI
-hxJ
-aDa
-okR
-bnv
-bVm
-oSz
-ddV
-okR
-dYk
-xsI
-fsz
-tWC
 fsz
 gfQ
 eGL
@@ -95903,21 +96120,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-xsI
-mTy
-aDq
-okR
-oSz
-xxJ
-oSz
-pUc
-dpQ
-dYM
-xsI
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96160,21 +96377,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
-xsI
-okN
-aDq
-uAp
-oSz
-aDq
-oSz
-awg
-uAp
-dYT
-xsI
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96416,22 +96633,22 @@ gfQ
 gfQ
 gfQ
 gfQ
-wzW
-tWC
 gfQ
-vlZ
-vlZ
-nbM
-nbM
-nbM
-bVH
-nbM
-nbM
-nbM
-vlZ
-vlZ
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96673,23 +96890,23 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-tWC
-fsz
-vlZ
-dnt
-aEn
-alf
-bov
-lEq
-cLg
-rRc
-rAY
-ear
-vlZ
-fsz
-tWC
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96931,21 +97148,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-vlZ
-rYm
-aFb
-tRF
-fRe
-qNI
-fRe
-eGE
-dvQ
-eat
-vlZ
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97188,21 +97405,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
-vlZ
-alu
-uFD
-wCu
-bqM
-bWr
-cLq
-wCu
-dwW
-eaF
-vlZ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97445,21 +97662,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-vlZ
-anC
-qxp
-wCu
-ptT
-bXN
-cLC
-wCu
-dxM
-eaS
-vlZ
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97701,23 +97918,23 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-tWC
-fsz
-vlZ
-apd
-hWR
-kwM
-xFV
-ccr
-cMe
-auw
-dCj
-eeU
-vlZ
-fsz
-tWC
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97959,21 +98176,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-vlZ
-oRt
-aFc
-aYt
-xio
-poM
-cMG
-dex
-dEg
-efo
-vlZ
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98216,21 +98433,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-tWC
 gfQ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
-vlZ
 gfQ
-tWC
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98473,21 +98690,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-gfQ
-gfQ
-gfQ
-fsz
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98730,21 +98947,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-fsz
-tWC
-tWC
-tWC
-tWC
-tWC
-fsz
-tWC
-tWC
-tWC
-tWC
-tWC
-fsz
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98991,13 +99208,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19718,6 +19718,7 @@
 	name = "Private Channel";
 	pixel_y = -40
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "btZ" = (
@@ -37692,6 +37693,11 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"kak" = (
+/obj/structure/cable,
+/obj/structure/secure_safe/caps_spare,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "kat" = (
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "Prison Exterior";
@@ -42029,11 +42035,6 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
-"qdd" = (
-/obj/structure/cable,
-/obj/structure/secure_safe/caps_spare,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "qdg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43329,10 +43330,8 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "rMV" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/super/full,
 /turf/open/floor/iron/white,
 /area/station/ai_monitored/turret_protected/ai)
 "rMZ" = (
@@ -79309,7 +79308,7 @@ asS
 asS
 asS
 aya
-qdd
+kak
 aAB
 aBs
 aCM

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -72,19 +72,20 @@
 "aam" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aap" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aas" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aat" = (
 /obj/effect/landmark/start/atmospheric_technician,
@@ -100,10 +101,13 @@
 	c_tag = "Genetics";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aav" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aax" = (
@@ -114,13 +118,13 @@
 /area/space/nearstation)
 "aay" = (
 /obj/machinery/dna_scannernew,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aaz" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aaB" = (
 /obj/structure/disposalpipe/segment{
@@ -160,7 +164,7 @@
 	pixel_y = 12
 	},
 /obj/structure/sign/poster/official/science/directional/south,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "aaH" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -1209,6 +1213,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aeT" = (
@@ -2938,7 +2943,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "akD" = (
@@ -13089,6 +13094,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aUw" = (
@@ -14062,6 +14070,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aXC" = (
@@ -20137,6 +20148,10 @@
 /area/station/science/robotics/lab)
 "bvS" = (
 /obj/structure/sink/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bvT" = (
@@ -20988,6 +21003,7 @@
 /area/station/maintenance/department/engine)
 "bzj" = (
 /obj/structure/water_source/puddle,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "bzk" = (
@@ -22800,6 +22816,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bGK" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bGL" = (
@@ -23056,6 +23075,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -23645,7 +23667,7 @@
 /obj/machinery/dna_infuser,
 /obj/item/infuser_book,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "bKV" = (
 /obj/structure/disposalpipe/segment{
@@ -24387,7 +24409,7 @@
 	pixel_y = -4;
 	pixel_x = -5
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "bOe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -30219,6 +30241,9 @@
 /area/station/tcommsat/computer)
 "cme" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "cmf" = (
@@ -34444,6 +34469,9 @@
 "feS" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "feU" = (
@@ -35861,6 +35889,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "hnt" = (
@@ -36648,8 +36677,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iyy" = (
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	name = "Supplies"
+	},
+/obj/item/vending_refill/custom,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/sales_tagger,
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "iyJ" = (
@@ -38239,7 +38275,7 @@
 /area/station/maintenance/department/science/xenobiology)
 "kQy" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "kQZ" = (
 /obj/structure/closet,
@@ -38597,6 +38633,9 @@
 "lqC" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "lqE" = (
@@ -41098,7 +41137,7 @@
 	pixel_x = 10;
 	pixel_y = 3
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "oMN" = (
 /turf/open/floor/iron/stairs/left,
@@ -41544,6 +41583,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "ptV" = (
@@ -47291,6 +47331,9 @@
 /area/station/medical/medbay/lobby)
 "xts" = (
 /obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
 /turf/open/floor/iron/white,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -5432,7 +5432,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "atY" = (
@@ -42030,6 +42029,11 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
+"qdd" = (
+/obj/structure/cable,
+/obj/structure/secure_safe/caps_spare,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "qdg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79305,7 +79309,7 @@ asS
 asS
 asS
 aya
-oQp
+qdd
 aAB
 aBs
 aCM


### PR DESCRIPTION
## About The Pull Request

Added a lil baby AI satellite to Cube, restored AI sat on Lima and combined satellite with tcomms. Improved camera coverage on both maps. Fixes spare safe on all our maps. Adjust layout of Cube cargo and sci slightly.

## Why It's Good For The Game

Fun new AI content doesn't work if we don't have AI spawns. Also I guess they can be fun places for antics. Included the triple AI spawns on a couple maps in case we ever want to push that button.

Cube: experimentor was locked behind robotics lab, made it more accessible for other scientists and added cytology lab. Moved server room, drone bay, and bitrunning out of maint to make these rooms less awkward to find.

## Changelog

:cl:
add: AI satellites to old maps
fix: Various department rooms moved out of maints
/:cl: