### PR TITLE
Lima fix 8.21.24

### DIFF
--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3675,13 +3675,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"aTB" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "aTL" = (
 /obj/structure/table,
 /obj/machinery/light_switch/directional/west{
@@ -6705,6 +6698,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
+"bWw" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "bWJ" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
@@ -7134,11 +7132,6 @@
 "ckU" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
-"ckX" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "clg" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/servo,
@@ -8576,6 +8569,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/cmo/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
 "cWf" = (
@@ -11894,6 +11888,15 @@
 /obj/machinery/computer/security/telescreen/vault/directional/north,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hop)
+"eyx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "eyJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16485,7 +16488,6 @@
 /area/station/science/ordnance/bomb)
 "gLT" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen/cmo/directional/north,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
@@ -20992,13 +20994,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"jps" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "jpK" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -22606,6 +22601,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"kgq" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "kgx" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
@@ -28309,12 +28311,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
-"nve" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "nvy" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -35978,6 +35974,13 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
+"rXY" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "rYg" = (
 /obj/structure/sign/warning/pods/directional/west,
 /obj/machinery/space_heater,
@@ -38823,6 +38826,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"tDE" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "tDH" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights,
@@ -39469,15 +39478,6 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"tTk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "tTo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance"
@@ -62072,7 +62072,7 @@ dBi
 gfQ
 uWh
 oyM
-nve
+tDE
 mgu
 xbl
 xbl
@@ -77294,7 +77294,7 @@ epW
 sau
 xZq
 kGa
-ckX
+bWw
 kgx
 tfS
 oim
@@ -82374,7 +82374,7 @@ lVT
 fuo
 ptv
 tIy
-tTk
+eyx
 ktL
 kQm
 mbb
@@ -89818,7 +89818,7 @@ yeH
 xII
 tYk
 ydJ
-jps
+kgq
 aOh
 amM
 mCe
@@ -95986,7 +95986,7 @@ eGL
 aHJ
 eOw
 eOw
-aTB
+rXY
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -8946,6 +8946,12 @@
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/iron/white/telecomms,
 /area/station/tcommsat/server)
+"deA" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "deL" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -15528,6 +15534,7 @@
 "gmZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/engineering_all,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "gne" = (
@@ -16018,6 +16025,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"gyS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "gze" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19466,7 +19480,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "iwm" = (
-/obj/machinery/light_switch/directional/east,
 /obj/structure/table,
 /obj/item/stack/cable_coil{
 	pixel_x = -3;
@@ -19822,13 +19835,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
-"iEZ" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "iFg" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -20052,13 +20058,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"iKX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "iLc" = (
 /obj/structure/table,
 /obj/item/aicard{
@@ -20109,15 +20108,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/misc/grass/jungle,
 /area/station/security/prison)
-"iNw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "iNP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -20814,12 +20804,6 @@
 /obj/effect/spawner/atmos_canister/nitrous_oxide,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"jjY" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "jkp" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay Treatment Center";
@@ -26956,6 +26940,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/station/cargo/office)
+"mFf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "mFo" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -30409,6 +30402,11 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"oGC" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "oGW" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mix Tank Access"
@@ -31190,11 +31188,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/service/bar)
-"phn" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "phw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -38995,6 +38988,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"tHw" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "tIg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -62075,7 +62075,7 @@ dBi
 gfQ
 uWh
 oyM
-jjY
+deA
 mgu
 xbl
 xbl
@@ -77297,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-phn
+oGC
 kgx
 tfS
 oim
@@ -80358,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-iKX
+gyS
 gRG
 gRG
 rSg
@@ -82377,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-iNw
+mFf
 ktL
 kQm
 mbb
@@ -95989,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-iEZ
+tHw
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3419,11 +3419,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPL" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "aPS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
@@ -10826,11 +10825,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"dZZ" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "eaa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -11534,13 +11528,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/command/heads_quarters/ce)
-"erp" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "erq" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -19185,6 +19172,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"imV" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "inh" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -20421,15 +20415,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
-"iWJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "iWT" = (
 /turf/open/floor/iron/white/textured,
 /area/station/security/prison/safe)
@@ -22708,6 +22693,12 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"kjd" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "kje" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -22960,13 +22951,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"krW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "krX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -26049,6 +26033,13 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"mdB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "mdK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
@@ -33002,13 +32993,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"qjn" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "qjF" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -34153,6 +34137,10 @@
 /obj/item/storage/bag/trash,
 /obj/item/storage/bag/trash,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = 22
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "qQH" = (
@@ -35883,6 +35871,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"rVz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "rVI" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -43281,6 +43278,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/hallway/primary/port)
+"wgH" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "wgS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43319,10 +43323,6 @@
 	pixel_y = 25
 	},
 /obj/item/key/janitor,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
@@ -62075,7 +62075,7 @@ dBi
 gfQ
 uWh
 oyM
-aPL
+kjd
 mgu
 xbl
 xbl
@@ -77297,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-dZZ
+aPL
 kgx
 tfS
 oim
@@ -80358,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-krW
+mdB
 gRG
 gRG
 rSg
@@ -82377,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-iWJ
+rVz
 ktL
 kQm
 mbb
@@ -89821,7 +89821,7 @@ yeH
 xII
 tYk
 ydJ
-erp
+wgH
 aOh
 amM
 mCe
@@ -95989,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-qjn
+imV
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -6272,6 +6272,13 @@
 	planetary_atmos = 0
 	},
 /area/station/service/hydroponics/garden)
+"bNg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "bNj" = (
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
@@ -12555,16 +12562,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"eMs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "eMv" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"eML" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "eMR" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -16486,13 +16497,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
-"gMd" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "gMm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -17753,6 +17757,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/surgery)
+"hwR" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "hxa" = (
 /obj/machinery/firealarm/directional/north,
 /obj/item/radio/intercom/directional/west,
@@ -30012,6 +30023,13 @@
 /obj/effect/landmark/start/clown,
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
+"ouA" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "ouG" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -33850,13 +33868,6 @@
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
-"qHZ" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "qId" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/siding/dark{
@@ -33983,7 +33994,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
@@ -36240,6 +36250,11 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"sfQ" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "sgv" = (
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -43311,15 +43326,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
-"wiI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "wjf" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/east{
@@ -77291,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-eML
+sfQ
 kgx
 tfS
 oim
@@ -80352,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-eLy
+bNg
 gRG
 gRG
 rSg
@@ -82371,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-wiI
+eMs
 ktL
 kQm
 mbb
@@ -89815,7 +89821,7 @@ yeH
 xII
 tYk
 ydJ
-qHZ
+hwR
 aOh
 amM
 mCe
@@ -95983,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-gMd
+ouA
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -6272,13 +6272,6 @@
 	planetary_atmos = 0
 	},
 /area/station/service/hydroponics/garden)
-"bNg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "bNj" = (
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
@@ -6625,6 +6618,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"bVh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "bVj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -9437,6 +9439,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dqV" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "drC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -12562,15 +12571,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
-"eMs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "eMv" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -17757,13 +17757,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/surgery)
-"hwR" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "hxa" = (
 /obj/machinery/firealarm/directional/north,
 /obj/item/radio/intercom/directional/west,
@@ -30023,13 +30016,6 @@
 /obj/effect/landmark/start/clown,
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
-"ouA" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "ouG" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -36250,11 +36236,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"sfQ" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "sgv" = (
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -36268,6 +36249,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"sgU" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "shm" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
 /obj/effect/turf_decal/siding/dark{
@@ -42224,6 +42210,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"vCo" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "vCv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46947,6 +46940,13 @@
 "yeH" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
+"yeV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "yfc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -77297,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-sfQ
+sgU
 kgx
 tfS
 oim
@@ -80358,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-bNg
+yeV
 gRG
 gRG
 rSg
@@ -82377,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-eMs
+bVh
 ktL
 kQm
 mbb
@@ -89821,7 +89821,7 @@ yeH
 xII
 tYk
 ydJ
-hwR
+vCo
 aOh
 amM
 mCe
@@ -95989,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-ouA
+dqV
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -14150,6 +14150,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"fBv" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "fBz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -17274,8 +17280,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen/interrogation/directional/south,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "hia" = (
@@ -40062,11 +40068,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "ujZ" = (
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/computer/security/telescreen/interrogation/directional/south,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "uks" = (
@@ -62048,7 +62054,7 @@ dBi
 gfQ
 uWh
 oyM
-boO
+fBv
 mgu
 xbl
 xbl

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -26107,16 +26107,16 @@
 /area/station/maintenance/port)
 "mge" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Research Lab Desk";
-	req_access = list("science")
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
 	name = "Research Lab Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/item/pen,
+/obj/machinery/door/window/left/directional/south{
+	name = "Research Lab Desk";
+	req_access = list("science")
+	},
 /turf/open/floor/plating,
 /area/station/science/lab)
 "mgg" = (
@@ -39686,10 +39686,6 @@
 /area/station/commons/dorms)
 "tXm" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Research Lab Desk";
-	req_access = list("science")
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
 	name = "Research Lab Shutters"
@@ -39698,6 +39694,10 @@
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
+	},
+/obj/machinery/door/window/right/directional/south{
+	name = "Research Lab Desk";
+	req_access = list("science")
 	},
 /turf/open/floor/plating,
 /area/station/science/lab)

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -2251,15 +2251,6 @@
 /obj/effect/spawner/random/medical/memeorgans,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"ayv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "ayF" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/storage/box/silver_ids,
@@ -3428,10 +3419,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPL" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "aPS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
@@ -6146,13 +6138,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"bJX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "bKk" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -6291,13 +6276,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
-"bNr" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "bNt" = (
 /obj/item/electronics/apc,
 /obj/item/electronics/airlock{
@@ -10848,6 +10826,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"dZZ" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "eaa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -11551,6 +11534,13 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/command/heads_quarters/ce)
+"erp" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "erq" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -11855,6 +11845,7 @@
 "exL" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
+/obj/machinery/computer/security/telescreen/vault/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "exZ" = (
@@ -11904,7 +11895,6 @@
 "eyr" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
-/obj/machinery/computer/security/telescreen/vault/directional/north,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hop)
 "eyJ" = (
@@ -20431,6 +20421,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"iWJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "iWT" = (
 /turf/open/floor/iron/white/textured,
 /area/station/security/prison/safe)
@@ -22961,6 +22960,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"krW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "krX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -25172,12 +25178,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"lCQ" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "lDb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -33002,6 +33002,13 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"qjn" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "qjF" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -46939,13 +46946,6 @@
 /area/station/solars/port/fore)
 "yeH" = (
 /turf/closed/wall,
-/area/station/maintenance/fore)
-"yeL" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
 /area/station/maintenance/fore)
 "yfc" = (
 /obj/effect/turf_decal/siding/white{
@@ -62075,7 +62075,7 @@ dBi
 gfQ
 uWh
 oyM
-lCQ
+aPL
 mgu
 xbl
 xbl
@@ -77297,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-aPL
+dZZ
 kgx
 tfS
 oim
@@ -80358,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-bJX
+krW
 gRG
 gRG
 rSg
@@ -82377,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-ayv
+iWJ
 ktL
 kQm
 mbb
@@ -89821,7 +89821,7 @@ yeH
 xII
 tYk
 ydJ
-yeL
+erp
 aOh
 amM
 mCe
@@ -95989,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-bNr
+qjn
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -26240,9 +26240,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "mjJ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/cargo/storage)
 "mjK" = (
 /obj/machinery/seed_extractor,
@@ -71603,7 +71602,7 @@ gfQ
 xfU
 fVy
 oYO
-xfU
+xEy
 oYO
 hhE
 xfU
@@ -72117,7 +72116,7 @@ xfU
 xfU
 fVy
 gFQ
-xfU
+xEy
 gFQ
 hhE
 xfU

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3419,9 +3419,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPL" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/carpet/royalblue,
-/area/station/command/heads_quarters/captain)
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "aPS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
@@ -6698,11 +6700,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
-"bWw" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "bWJ" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
@@ -11888,15 +11885,6 @@
 /obj/machinery/computer/security/telescreen/vault/directional/north,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hop)
-"eyx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "eyJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -12572,6 +12560,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"eML" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "eMR" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -16493,6 +16486,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/cmo)
+"gMd" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "gMm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -22601,13 +22601,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"kgq" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "kgx" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
@@ -33857,6 +33850,13 @@
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
+"qHZ" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "qId" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/siding/dark{
@@ -35974,13 +35974,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/orange,
 /area/station/service/theater)
-"rXY" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "rYg" = (
 /obj/structure/sign/warning/pods/directional/west,
 /obj/machinery/space_heater,
@@ -38826,12 +38819,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"tDE" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "tDH" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights,
@@ -43324,6 +43311,15 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
+"wiI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "wjf" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/east{
@@ -46177,6 +46173,7 @@
 "xLU" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "xMg" = (
@@ -62072,7 +62069,7 @@ dBi
 gfQ
 uWh
 oyM
-tDE
+aPL
 mgu
 xbl
 xbl
@@ -77294,7 +77291,7 @@ epW
 sau
 xZq
 kGa
-bWw
+eML
 kgx
 tfS
 oim
@@ -82374,7 +82371,7 @@ lVT
 fuo
 ptv
 tIy
-eyx
+wiI
 ktL
 kQm
 mbb
@@ -85948,7 +85945,7 @@ azz
 pCJ
 aRq
 axj
-aPL
+pCJ
 ahA
 cNn
 aZy
@@ -89818,7 +89815,7 @@ yeH
 xII
 tYk
 ydJ
-kgq
+qHZ
 aOh
 amM
 mCe
@@ -95986,7 +95983,7 @@ eGL
 aHJ
 eOw
 eOw
-rXY
+gMd
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3247,9 +3247,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aOh" = (
-/obj/machinery/computer/security/telescreen{
-	name = "Test Chamber Monitor"
-	},
 /obj/machinery/button/door{
 	id = "testlab";
 	name = "Test Chamber Blast Doors";
@@ -11180,6 +11177,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"eie" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "eii" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/landmark/start/hangover/closet,
@@ -14150,12 +14154,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"fBv" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "fBz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -14820,6 +14818,15 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
+"fSw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "fSF" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
@@ -23026,10 +23033,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ktR" = (
@@ -30146,6 +30149,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"oAq" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "oAs" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/showroomfloor,
@@ -38977,6 +38987,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
+"tIm" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "tIw" = (
 /obj/machinery/airlock_sensor/incinerator_ordmix{
 	pixel_x = 25
@@ -45002,9 +45018,6 @@
 /area/station/maintenance/fore)
 "xgl" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	name = "Test Chamber Monitor"
-	},
 /obj/machinery/button/door{
 	id = "misclab";
 	pixel_y = 25
@@ -62054,7 +62067,7 @@ dBi
 gfQ
 uWh
 oyM
-fBv
+tIm
 mgu
 xbl
 xbl
@@ -82356,7 +82369,7 @@ lVT
 fuo
 ptv
 tIy
-mbb
+fSw
 ktL
 kQm
 mbb
@@ -89800,7 +89813,7 @@ yeH
 xII
 tYk
 ydJ
-ydJ
+eie
 aOh
 amM
 mCe
@@ -95968,7 +95981,7 @@ eGL
 aHJ
 eOw
 eOw
-nmU
+oAq
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -2251,6 +2251,15 @@
 /obj/effect/spawner/random/medical/memeorgans,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ayv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "ayF" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/storage/box/silver_ids,
@@ -3419,11 +3428,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPL" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "aPS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
@@ -6138,6 +6146,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"bJX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "bKk" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
@@ -6276,6 +6291,13 @@
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"bNr" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "bNt" = (
 /obj/item/electronics/apc,
 /obj/item/electronics/airlock{
@@ -6618,15 +6640,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
-"bVh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "bVj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -9439,13 +9452,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"dqV" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "drC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -23731,14 +23737,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "kMl" = (
-/obj/machinery/light_switch/directional/south{
-	pixel_x = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/research/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "kMW" = (
@@ -24155,7 +24159,6 @@
 /area/station/medical/exam_room)
 "kYt" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen/research/directional/north,
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -25169,6 +25172,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"lCQ" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "lDb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -25281,6 +25290,9 @@
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
@@ -36249,11 +36261,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"sgU" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "shm" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
 /obj/effect/turf_decal/siding/dark{
@@ -42210,13 +42217,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"vCo" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "vCv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46940,13 +46940,13 @@
 "yeH" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
-"yeV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+"yeL" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "yfc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -62075,7 +62075,7 @@ dBi
 gfQ
 uWh
 oyM
-aPL
+lCQ
 mgu
 xbl
 xbl
@@ -77297,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-sgU
+aPL
 kgx
 tfS
 oim
@@ -80358,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-yeV
+bJX
 gRG
 gRG
 rSg
@@ -82377,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-bVh
+ayv
 ktL
 kQm
 mbb
@@ -89821,7 +89821,7 @@ yeH
 xII
 tYk
 ydJ
-vCo
+yeL
 aOh
 amM
 mCe
@@ -95989,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-dqV
+bNr
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3419,12 +3419,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPL" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "aPS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
@@ -8946,12 +8944,6 @@
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/iron/white/telecomms,
 /area/station/tcommsat/server)
-"deA" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "deL" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -16009,6 +16001,13 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"gxS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "gxW" = (
 /obj/machinery/air_sensor/mix_tank{
 	chamber_id = "mix2";
@@ -16025,13 +16024,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"gyS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "gze" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16618,6 +16610,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
+"gON" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "gOO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -23735,6 +23733,10 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/research/directional/south,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -24;
+	pixel_y = 12
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "kMW" = (
@@ -25277,9 +25279,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light_switch/directional/south{
-	pixel_x = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "lGt" = (
@@ -26128,6 +26127,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"mgp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "mgu" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -26701,6 +26709,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"mxi" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "mxL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
 	dir = 4
@@ -26940,15 +26955,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/station/cargo/office)
-"mFf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "mFo" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -30402,11 +30408,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"oGC" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "oGW" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mix Tank Access"
@@ -38988,13 +38989,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"tHw" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "tIg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -40861,6 +40855,13 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"uFP" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "uFX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -62075,7 +62076,7 @@ dBi
 gfQ
 uWh
 oyM
-deA
+gON
 mgu
 xbl
 xbl
@@ -77297,7 +77298,7 @@ epW
 sau
 xZq
 kGa
-oGC
+aPL
 kgx
 tfS
 oim
@@ -80358,7 +80359,7 @@ nGX
 ogW
 gTv
 vVO
-gyS
+gxS
 gRG
 gRG
 rSg
@@ -82377,7 +82378,7 @@ lVT
 fuo
 ptv
 tIy
-mFf
+mgp
 ktL
 kQm
 mbb
@@ -89821,7 +89822,7 @@ yeH
 xII
 tYk
 ydJ
-aPL
+mxi
 aOh
 amM
 mCe
@@ -95989,7 +95990,7 @@ eGL
 aHJ
 eOw
 eOw
-tHw
+uFP
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3675,6 +3675,13 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"aTB" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "aTL" = (
 /obj/structure/table,
 /obj/machinery/light_switch/directional/west{
@@ -7127,6 +7134,11 @@
 "ckU" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
+"ckX" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "clg" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/servo,
@@ -16409,13 +16421,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"gJY" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "gKa" = (
 /obj/machinery/light/directional/south,
 /obj/structure/chair/stool/directional/east,
@@ -20987,6 +20992,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"jps" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "jpK" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -28297,6 +28309,12 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
+"nve" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "nvy" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -32104,7 +32122,7 @@
 /obj/machinery/camera/autoname/directional/south{
 	network = list("ss13","bar")
 	},
-/obj/machinery/computer/security/telescreen/bar/directional/north,
+/obj/machinery/computer/security/telescreen/bar/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "pHP" = (
@@ -32164,12 +32182,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"pJa" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "pJf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -35227,13 +35239,6 @@
 "rzN" = (
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
-"rzU" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "rAm" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/sepia,
@@ -39464,6 +39469,15 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"tTk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "tTo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance"
@@ -40924,15 +40938,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"uIf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "uIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
@@ -62067,7 +62072,7 @@ dBi
 gfQ
 uWh
 oyM
-pJa
+nve
 mgu
 xbl
 xbl
@@ -77289,7 +77294,7 @@ epW
 sau
 xZq
 kGa
-pnY
+ckX
 kgx
 tfS
 oim
@@ -82369,7 +82374,7 @@ lVT
 fuo
 ptv
 tIy
-uIf
+tTk
 ktL
 kQm
 mbb
@@ -89813,7 +89818,7 @@ yeH
 xII
 tYk
 ydJ
-rzU
+jps
 aOh
 amM
 mCe
@@ -95981,7 +95986,7 @@ eGL
 aHJ
 eOw
 eOw
-gJY
+aTB
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -11177,13 +11177,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"eie" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "eii" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/landmark/start/hangover/closet,
@@ -14818,15 +14811,6 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
-"fSw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "fSF" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
@@ -16425,6 +16409,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"gJY" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "gKa" = (
 /obj/machinery/light/directional/south,
 /obj/structure/chair/stool/directional/east,
@@ -30149,13 +30140,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"oAq" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "oAs" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/showroomfloor,
@@ -32180,6 +32164,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"pJa" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "pJf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -35237,6 +35227,13 @@
 "rzN" = (
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
+"rzU" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "rAm" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/sepia,
@@ -38825,7 +38822,7 @@
 /obj/structure/rack,
 /obj/item/storage/box/lights,
 /obj/item/assault_pod/mining,
-/obj/machinery/computer/security/telescreen/auxbase/directional/west,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "tDS" = (
@@ -38987,12 +38984,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
-"tIm" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "tIw" = (
 /obj/machinery/airlock_sensor/incinerator_ordmix{
 	pixel_x = 25
@@ -40933,6 +40924,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"uIf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "uIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
@@ -62067,7 +62067,7 @@ dBi
 gfQ
 uWh
 oyM
-tIm
+pJa
 mgu
 xbl
 xbl
@@ -82369,7 +82369,7 @@ lVT
 fuo
 ptv
 tIy
-fSw
+uIf
 ktL
 kQm
 mbb
@@ -89813,7 +89813,7 @@ yeH
 xII
 tYk
 ydJ
-eie
+rzU
 aOh
 amM
 mCe
@@ -95981,7 +95981,7 @@ eGL
 aHJ
 eOw
 eOw
-oAq
+gJY
 hcS
 hOF
 jGS

--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -3419,10 +3419,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/captain)
 "aPL" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "aPS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/harmful,
@@ -7206,6 +7208,10 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Art Storage"
 	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = 22
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "cmz" = (
@@ -7218,10 +7224,6 @@
 /obj/machinery/light/small/directional/north,
 /obj/item/radio/intercom{
 	pixel_y = 25
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 22
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
@@ -19172,13 +19174,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"imV" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "inh" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -19827,6 +19822,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
+"iEZ" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/fore)
 "iFg" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -20050,6 +20052,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"iKX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "iLc" = (
 /obj/structure/table,
 /obj/item/aicard{
@@ -20100,6 +20109,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/misc/grass/jungle,
 /area/station/security/prison)
+"iNw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	name = "Medbay Monitor"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "iNP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -20796,6 +20814,12 @@
 /obj/effect/spawner/atmos_canister/nitrous_oxide,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"jjY" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/computer/security/telescreen/interrogation/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "jkp" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay Treatment Center";
@@ -22693,12 +22717,6 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"kjd" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/computer/security/telescreen/interrogation/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "kje" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -26033,13 +26051,6 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"mdB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
 "mdK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
@@ -31179,6 +31190,11 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/service/bar)
+"phn" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "phw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -35871,15 +35887,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"rVz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "rVI" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -43278,13 +43285,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/hallway/primary/port)
-"wgH" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	name = "Medbay Monitor"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore)
 "wgS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62075,7 +62075,7 @@ dBi
 gfQ
 uWh
 oyM
-kjd
+jjY
 mgu
 xbl
 xbl
@@ -77297,7 +77297,7 @@ epW
 sau
 xZq
 kGa
-aPL
+phn
 kgx
 tfS
 oim
@@ -80358,7 +80358,7 @@ nGX
 ogW
 gTv
 vVO
-mdB
+iKX
 gRG
 gRG
 rSg
@@ -82377,7 +82377,7 @@ lVT
 fuo
 ptv
 tIy
-rVz
+iNw
 ktL
 kQm
 mbb
@@ -89821,7 +89821,7 @@ yeH
 xII
 tYk
 ydJ
-wgH
+aPL
 aOh
 amM
 mCe
@@ -95989,7 +95989,7 @@ eGL
 aHJ
 eOw
 eOw
-imV
+iEZ
 hcS
 hOF
 jGS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed some things that wallening prep messed with. Telescreens mostly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Returns things back to normal(ish).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: changed charge shuttle buttons to be on wall.
fix: moved/replaced displaced telescreens
fix: moved a couple lightswitches that were under wall objects
fix: changed the walldoors at research reception to not be under the shutters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
